### PR TITLE
Change README start command to compile CSS as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Front end for klageskjema som skal legges ut på DittNAV.
 
 ## Kjøre lokalt
-`npm run start:js`
+`npm run start`
 
 ## Kjøre med docker-compose
 Kjøre med mock:


### PR DESCRIPTION
Nåværende kommando (`npm run start:js`) i `README.md` kompilerer ikke `LESS` filene.
Endret kommandoen til `npm run start` som kompilerer både `TS`/`TSX` og `LESS`.