### PR TITLE
Retrieves existing klage if previously begun.

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,10 @@
+{
+    "printWidth": 120,
+    "singleQuote": true,
+    "semi": true,
+    "tabWidth": 4,
+    "useTabs": false,
+    "trailingComma": "none",
+    "arrowParens": "avoid",
+    "bracketSpacing": true
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import { setValgtYtelse, setValgtTema, setKlageId } from './store/actions';
 import NotFoundPage from './pages/not-found/not-found-page';
 import NavFrontendSpinner from 'nav-frontend-spinner';
 import { CenteredContainer } from './styled-components/main-styled-components';
+import { Tema } from './types/tema';
 
 const App = (props: any) => {
     const [loading, setLoading] = useState<boolean>(true);
@@ -22,11 +23,24 @@ const App = (props: any) => {
             const query = queryString.parse(props.location.search);
 
             if (sessionStorage.getItem('nav.klage.klageId') && query && !query.klageid) {
-                if (query.tema && query.ytelse) {
+                if (query.tema) {
                     let cachedTema = sessionStorage.getItem('nav.klage.tema');
                     let cachedYtelse = sessionStorage.getItem('nav.klage.ytelse');
-                    if (cachedTema === query.tema && cachedYtelse === query.ytelse) {
-                        dispatch(setKlageId(sessionStorage.getItem('nav.klage.klageId') as string));
+                    if (cachedTema === query.tema) {
+                        if (
+                            cachedYtelse === query.ytelse ||
+                            (query.ytelse === undefined && cachedYtelse === Tema[cachedTema])
+                        ) {
+                            if (query.saksnummer || sessionStorage.getItem('nav.klage.saksnr')) {
+                                if (query.saksnummer === sessionStorage.getItem('nav.klage.saksnr')) {
+                                    dispatch(setKlageId(sessionStorage.getItem('nav.klage.klageId') as string));
+                                } else {
+                                    sessionStorage.removeItem('nav.klage.saksnr');
+                                }
+                            } else {
+                                dispatch(setKlageId(sessionStorage.getItem('nav.klage.klageId') as string));
+                            }
+                        }
                     }
                 } else {
                     dispatch(setKlageId(sessionStorage.getItem('nav.klage.klageId') as string));
@@ -57,7 +71,7 @@ const App = (props: any) => {
         } else {
             setLoading(false);
         }
-    }, [dispatch, props.location.search]);
+    }, [dispatch, props.location.search, props.chosenYtelse]);
 
     if (loading) {
         return (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,7 @@ import { withRouter } from 'react-router-dom';
 import queryString from 'query-string';
 import { getTemaObject } from './services/klageService';
 import { useDispatch } from 'react-redux';
-import { setValgtYtelse, setValgtTema } from './store/actions';
+import { setValgtYtelse, setValgtTema, setKlageId } from './store/actions';
 import NotFoundPage from './pages/not-found/not-found-page';
 import NavFrontendSpinner from 'nav-frontend-spinner';
 import { CenteredContainer } from './styled-components/main-styled-components';
@@ -20,6 +20,20 @@ const App = (props: any) => {
     useEffect(() => {
         if (props.location.search !== '') {
             const query = queryString.parse(props.location.search);
+
+            if (sessionStorage.getItem('nav.klage.klageId') && query && !query.klageid) {
+                if (query.tema && query.ytelse) {
+                    let cachedTema = sessionStorage.getItem('nav.klage.tema');
+                    let cachedYtelse = sessionStorage.getItem('nav.klage.ytelse');
+                    if (cachedTema === query.tema && cachedYtelse === query.ytelse) {
+                        dispatch(setKlageId(sessionStorage.getItem('nav.klage.klageId') as string));
+                    }
+                } else {
+                    dispatch(setKlageId(sessionStorage.getItem('nav.klage.klageId') as string));
+                }
+                setLoading(false);
+            }
+
             if (query && query.tema) {
                 const tema = query.tema.toString();
                 dispatch(setValgtTema(tema));

--- a/src/components/begrunnelse/begrunnelse.tsx
+++ b/src/components/begrunnelse/begrunnelse.tsx
@@ -96,7 +96,10 @@ const Begrunnelse = (props: any) => {
                         console.log(response);
                         dispatch({
                             type: 'VEDLEGG_ADD_SUCCESS',
-                            value: { status: VEDLEGG_STATUS.OK, vedlegg: toVedleggProps(response) }
+                            value: {
+                                status: VEDLEGG_STATUS.OK,
+                                vedlegg: toVedleggProps(response)
+                            }
                         });
                         setVedleggLoading(false);
                     })

--- a/src/components/begrunnelse/begrunnelse.tsx
+++ b/src/components/begrunnelse/begrunnelse.tsx
@@ -13,7 +13,7 @@ import { Hovedknapp, Knapp } from 'nav-frontend-knapper';
 import { Element, Normaltekst, Undertekst, Undertittel } from 'nav-frontend-typografi';
 import { toVedleggProps, VEDLEGG_STATUS, VedleggErrorMessages, VedleggProps } from '../../types/vedlegg';
 import VedleggVisning from './vedlegg';
-import { postNewKlage, updateKlage } from '../../store/actions';
+import { postNewKlage, setKlageId, updateKlage } from '../../store/actions';
 import { useDispatch, useSelector } from 'react-redux';
 import { Store } from '../../store/reducer';
 import { addVedleggToKlage, deleteVedlegg } from '../../services/fileService';
@@ -52,10 +52,13 @@ const Begrunnelse = (props: any) => {
     useEffect(() => {
         setActiveBegrunnelse(activeKlage.fritekst);
         setDatoalternativ(activeKlageSkjema.datoalternativ);
+        if (activeKlage.id !== undefined) {
+            dispatch(setKlageId(String(activeKlage.id)));
+        }
         if (activeKlageSkjema.vedtaksdatoobjekt) {
             setActiveDatoISO(toISOString(activeKlageSkjema.vedtaksdatoobjekt));
         }
-    }, [activeKlage, activeKlageSkjema]);
+    }, [dispatch, activeKlage, activeKlageSkjema]);
 
     const INPUTDESCRIPTION =
         'Skriv inn hvilke endringer du ønsker i vedtaket, og beskriv hva du begrunner klagen med. Legg ved dokumenter som du mener kan være til støtte for klagen.';

--- a/src/components/begrunnelse/begrunnelse.tsx
+++ b/src/components/begrunnelse/begrunnelse.tsx
@@ -1,30 +1,28 @@
-import React, { useState, useRef, useEffect } from 'react';
-import { Textarea, RadioPanelGruppe } from 'nav-frontend-skjema';
+import React, { useEffect, useRef, useState } from 'react';
+import { RadioPanelGruppe, Textarea } from 'nav-frontend-skjema';
 import {
-    MarginContainer,
+    CenteredContainer,
     FlexCenteredContainer,
+    Margin40Container,
     Margin48Container,
     Margin48TopContainer,
-    MarginTopContainer,
-    Margin40Container,
-    CenteredContainer
+    MarginContainer,
+    MarginTopContainer
 } from '../../styled-components/main-styled-components';
 import { Hovedknapp, Knapp } from 'nav-frontend-knapper';
-import { Normaltekst, Undertittel, Element, Undertekst } from 'nav-frontend-typografi';
-import { VEDLEGG_STATUS, VedleggProps, toVedleggProps, VedleggErrorMessages } from '../../types/vedlegg';
+import { Element, Normaltekst, Undertekst, Undertittel } from 'nav-frontend-typografi';
+import { toVedleggProps, VEDLEGG_STATUS, VedleggErrorMessages, VedleggProps } from '../../types/vedlegg';
 import VedleggVisning from './vedlegg';
 import { postNewKlage, updateKlage } from '../../store/actions';
-import { useSelector, useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { Store } from '../../store/reducer';
 import { addVedleggToKlage, deleteVedlegg } from '../../services/fileService';
-import { klageSkjemaBasertPaaVedtak, KlageSkjema } from '../../types/klage';
-import { isValidDateString, toISOString } from '../../utils/date-util';
-import { AlertStripeFeil } from 'nav-frontend-alertstriper';
+import { KlageSkjema, klageSkjemaBasertPaaVedtak } from '../../types/klage';
+import { toISOString } from '../../utils/date-util';
+import AlertStripe, { AlertStripeFeil } from 'nav-frontend-alertstriper';
 import { datoValg } from './datoValg';
 import { Datovelger } from 'nav-datovelger';
 import NavFrontendSpinner from 'nav-frontend-spinner';
-import AlertStripe from 'nav-frontend-alertstriper';
-import { Tema } from '../../types/tema';
 import { getReferrer } from '../../services/klageService';
 
 const Begrunnelse = (props: any) => {
@@ -41,29 +39,16 @@ const Begrunnelse = (props: any) => {
     const [submitted, setSubmitted] = useState<boolean>(false);
 
     useEffect(() => {
-        if ((!activeKlage || !activeKlage.id) && klageId === '') {
+        if (klageId === '') {
             let klageskjema: KlageSkjema;
             if (props.chosenVedtak) {
                 klageskjema = klageSkjemaBasertPaaVedtak(props.chosenVedtak);
                 klageskjema.referrer = getReferrer();
-            } else {
-                klageskjema = {
-                    fritekst: activeBegrunnelse,
-                    tema: 'UKJ',
-                    ytelse: Tema['UKJ'],
-                    datoalternativ: datoalternativ,
-                    saksnummer: '',
-                    referrer: getReferrer()
-                };
-                if (activeDatoISO !== '' && isValidDateString(activeDatoISO)) {
-                    klageskjema.vedtaksdatoobjekt = new Date(activeDatoISO);
-                } else {
-                    klageskjema.vedtaksdatoobjekt = undefined;
-                }
+                dispatch(postNewKlage(klageskjema));
             }
-            dispatch(postNewKlage(klageskjema));
         }
-    }, [activeKlage, dispatch, activeBegrunnelse, activeDatoISO, datoalternativ, props.chosenVedtak, klageId]);
+    }, [dispatch, props.chosenVedtak, klageId]);
+
     useEffect(() => {
         setActiveBegrunnelse(activeKlage.fritekst);
         setDatoalternativ(activeKlageSkjema.datoalternativ);

--- a/src/components/form-landing/form-landing.tsx
+++ b/src/components/form-landing/form-landing.tsx
@@ -11,7 +11,9 @@ import Error from '../../components/error/error';
 
 const FormLanding = (props: any) => {
     const dispatch = useDispatch();
-    const { loading, chosenTema, chosenYtelse, getKlageError } = useSelector((state: Store) => state);
+    const { loading, chosenTema, chosenYtelse, getKlageError, klageId, activeKlage } = useSelector(
+        (state: Store) => state
+    );
 
     const [chosenVedtak, setChosenVedtak] = useState<Vedtak>();
     const [temaNotSet, setTemaNotSet] = useState<boolean>(false);
@@ -19,16 +21,21 @@ const FormLanding = (props: any) => {
     useEffect(() => {
         if (validVedtakQuery(props.query)) {
             dispatch(checkAuth(props.location.search));
-            if (props.query.klageid) {
-                dispatch(setKlageId(props.query.klageid as string))
-                dispatch(getExistingKlage(parseInt(props.query.klageid as string)))
+            if (props.query.klageid && klageId === '') {
+                dispatch(setKlageId(props.query.klageid as string));
             } else {
                 setChosenVedtak(elementAsVedtak(props.query));
             }
         } else {
             setTemaNotSet(chosenTema === '');
         }
-    }, [dispatch, props.location.search, props.query, chosenTema]);
+    }, [dispatch, props.location.search, props.query, klageId, chosenTema]);
+
+    useEffect(() => {
+        if (klageId !== '' && activeKlage.tema === '') {
+            dispatch(getExistingKlage(parseInt(klageId)));
+        }
+    }, [dispatch, klageId, activeKlage]);
 
     logInfo('Form landing page visited.', { chosenYtelse: chosenYtelse, referrer: document.referrer });
 
@@ -49,8 +56,7 @@ const FormLanding = (props: any) => {
             <Error
                 error={{
                     code: 400,
-                    text:
-                        'Klagen du ba om kan ikke hentes. Prøv på nytt fra lenken på Ditt NAV.'
+                    text: 'Klagen du ba om kan ikke hentes. Prøv på nytt fra lenken på Ditt NAV.'
                 }}
             />
         );

--- a/src/pages/form-landing-page/main-form-page.tsx
+++ b/src/pages/form-landing-page/main-form-page.tsx
@@ -40,8 +40,7 @@ const MainFormPage = (props: Props) => {
     };
 
     const previous = () => {
-        history.push(activeRoutes[activeStep - 1].path);
-        setActiveStep(activeStep - 1);
+        history.goBack();
     };
 
     return (

--- a/src/pages/oppsummering-skjema-page/oppsummering-skjema-page.tsx
+++ b/src/pages/oppsummering-skjema-page/oppsummering-skjema-page.tsx
@@ -43,6 +43,9 @@ const OppsummeringSkjemaPage = (props: any) => {
         finalizeKlage(activeKlage.id)
             .then(response => {
                 const finalizedDate = response.finalizedDate;
+                sessionStorage.removeItem('nav.klage.klageId');
+                sessionStorage.removeItem('nav.klage.tema');
+                sessionStorage.removeItem('nav.klage.ytelse');
                 history.push({ pathname: `/kvittering`, state: { finalizedDate } });
                 setIsLoading(false);
                 // TODO: Set success message

--- a/src/pages/oppsummering-skjema-page/oppsummering-skjema-page.tsx
+++ b/src/pages/oppsummering-skjema-page/oppsummering-skjema-page.tsx
@@ -46,6 +46,7 @@ const OppsummeringSkjemaPage = (props: any) => {
                 sessionStorage.removeItem('nav.klage.klageId');
                 sessionStorage.removeItem('nav.klage.tema');
                 sessionStorage.removeItem('nav.klage.ytelse');
+                sessionStorage.removeItem('nav.klage.saksnr');
                 history.push({ pathname: `/kvittering`, state: { finalizedDate } });
                 setIsLoading(false);
                 // TODO: Set success message

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -71,7 +71,7 @@ export function postNewKlage(klageskjema: KlageSkjema) {
     return function (dispatch: Dispatch<ActionTypes>) {
         return postKlage(klageSkjemaTilKlage(klageskjema))
             .then(response => {
-                setKlageId((response.id as unknown) as string, response.tema, response.ytelse);
+                setKlageId((response.id as unknown) as string, response.tema, response.ytelse, response.saksnummer);
                 dispatch({ type: 'KLAGE_POST_SUCCESS', payload: response, klageskjema: klageskjema });
             })
             .catch(err => {
@@ -96,13 +96,17 @@ export function getExistingKlage(klageId: number) {
     return function (dispatch: Dispatch<ActionTypes>) {
         return getKlage(klageId)
             .then(response => {
+                setStorageContent(response.tema, response.ytelse, response.saksnummer || '');
                 dispatch({ type: 'KLAGE_GET_SUCCESS', payload: response });
             })
             .catch(err => {
                 logError(err, 'Get existing klage failed');
-                sessionStorage.removeItem('nav.klage.klageId');
-                sessionStorage.removeItem('nav.klage.tema');
-                sessionStorage.removeItem('nav.klage.ytelse');
+                if (err.response.status !== 401) {
+                    sessionStorage.removeItem('nav.klage.klageId');
+                    sessionStorage.removeItem('nav.klage.tema');
+                    sessionStorage.removeItem('nav.klage.ytelse');
+                    sessionStorage.removeItem('nav.klage.saksnr');
+                }
                 dispatch({ type: 'KLAGE_GET_ERROR' });
             });
     };
@@ -120,19 +124,30 @@ export function setValgtTema(tema: string) {
     };
 }
 
-export function setKlageId(klageId: string, tema: string = '*UNKNOWN*', ytelse: string = '*UNKNOWN*') {
+export function setKlageId(
+    klageId: string,
+    tema: string = '*UNKNOWN*',
+    ytelse: string = '*UNKNOWN*',
+    saksnr: string = ''
+) {
     sessionStorage.removeItem('nav.klage.klageId');
     sessionStorage.setItem('nav.klage.klageId', klageId);
     if (tema !== '*UNKNOWN*' && ytelse !== '*UNKNOWN*') {
-        sessionStorage.removeItem('nav.klage.tema');
-        sessionStorage.setItem('nav.klage.tema', tema);
-        sessionStorage.removeItem('nav.klage.ytelse');
-        sessionStorage.setItem('nav.klage.ytelse', ytelse);
+        setStorageContent(tema, ytelse, saksnr);
     }
 
     return function (dispatch: Dispatch<ActionTypes>) {
         return dispatch({ type: 'KLAGE_ID_SET', value: klageId });
     };
+}
+
+export function setStorageContent(tema: string, ytelse: string, saksnr: string) {
+    sessionStorage.removeItem('nav.klage.tema');
+    sessionStorage.setItem('nav.klage.tema', tema);
+    sessionStorage.removeItem('nav.klage.ytelse');
+    sessionStorage.setItem('nav.klage.ytelse', ytelse);
+    sessionStorage.removeItem('nav.klage.saksnr');
+    sessionStorage.setItem('nav.klage.saksnr', saksnr);
 }
 
 export function sjekkAuth(response: Response, params: string) {

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -130,7 +130,6 @@ export function setKlageId(
     ytelse: string = '*UNKNOWN*',
     saksnr: string = ''
 ) {
-    sessionStorage.removeItem('nav.klage.klageId');
     sessionStorage.setItem('nav.klage.klageId', klageId);
     if (tema !== '*UNKNOWN*' && ytelse !== '*UNKNOWN*') {
         setStorageContent(tema, ytelse, saksnr);
@@ -142,11 +141,8 @@ export function setKlageId(
 }
 
 export function setStorageContent(tema: string, ytelse: string, saksnr: string) {
-    sessionStorage.removeItem('nav.klage.tema');
     sessionStorage.setItem('nav.klage.tema', tema);
-    sessionStorage.removeItem('nav.klage.ytelse');
     sessionStorage.setItem('nav.klage.ytelse', ytelse);
-    sessionStorage.removeItem('nav.klage.saksnr');
     sessionStorage.setItem('nav.klage.saksnr', saksnr);
 }
 

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -71,6 +71,7 @@ export function postNewKlage(klageskjema: KlageSkjema) {
     return function (dispatch: Dispatch<ActionTypes>) {
         return postKlage(klageSkjemaTilKlage(klageskjema))
             .then(response => {
+                setKlageId((response.id as unknown) as string, response.tema, response.ytelse);
                 dispatch({ type: 'KLAGE_POST_SUCCESS', payload: response, klageskjema: klageskjema });
             })
             .catch(err => {
@@ -99,6 +100,9 @@ export function getExistingKlage(klageId: number) {
             })
             .catch(err => {
                 logError(err, 'Get existing klage failed');
+                sessionStorage.removeItem('nav.klage.klageId');
+                sessionStorage.removeItem('nav.klage.tema');
+                sessionStorage.removeItem('nav.klage.ytelse');
                 dispatch({ type: 'KLAGE_GET_ERROR' });
             });
     };
@@ -116,7 +120,16 @@ export function setValgtTema(tema: string) {
     };
 }
 
-export function setKlageId(klageId: string) {
+export function setKlageId(klageId: string, tema: string = '*UNKNOWN*', ytelse: string = '*UNKNOWN*') {
+    sessionStorage.removeItem('nav.klage.klageId');
+    sessionStorage.setItem('nav.klage.klageId', klageId);
+    if (tema !== '*UNKNOWN*' && ytelse !== '*UNKNOWN*') {
+        sessionStorage.removeItem('nav.klage.tema');
+        sessionStorage.setItem('nav.klage.tema', tema);
+        sessionStorage.removeItem('nav.klage.ytelse');
+        sessionStorage.setItem('nav.klage.ytelse', ytelse);
+    }
+
     return function (dispatch: Dispatch<ActionTypes>) {
         return dispatch({ type: 'KLAGE_ID_SET', value: klageId });
     };

--- a/src/store/reducer.ts
+++ b/src/store/reducer.ts
@@ -87,8 +87,7 @@ const reducer = (state = initialState, action: ActionTypes): Store => {
             return {
                 ...state,
                 activeKlage: action.payload,
-                activeKlageSkjema: { ...state.activeKlageSkjema, ...action.klageskjema, ...action.payload },
-                klageId: action.payload.id?.toString() ?? initialState.klageId
+                activeKlageSkjema: { ...state.activeKlageSkjema, ...action.klageskjema, ...action.payload }
             };
         case 'KLAGE_GET_SUCCESS':
             const incomingVedlegg = action.payload.vedlegg?.map(function (e): VedleggProps {
@@ -105,6 +104,7 @@ const reducer = (state = initialState, action: ActionTypes): Store => {
                 activeKlage: action.payload,
                 activeKlageSkjema: klageTilKlageSkjema(action.payload),
                 chosenYtelse: action.payload.ytelse,
+                chosenTema: action.payload.tema,
                 activeVedlegg: incomingVedlegg!!,
                 klageId: action.payload.id?.toString() ?? initialState.klageId
             };


### PR DESCRIPTION
Allows reloading page without creating new klage.
Creates new klage if specified tema and ytelse differs from previously created klage.

Changes behaviour in "previous" in main-form-page, to keep query params.