### PR TITLE
Handle klage ID as string and number

### DIFF
--- a/src/clients/apiUrls.tsx
+++ b/src/clients/apiUrls.tsx
@@ -5,30 +5,29 @@ export const getUserDataUrl = () => `${Environment.REACT_APP_API_URL}/bruker`;
 
 export const getKlagerUrl = () => `${Environment.REACT_APP_API_URL}/klager`;
 
-export const getKlageByIdUrl = (id: string | number): string => `${Environment.REACT_APP_API_URL}/klager/${id}`;
-
-export const getKlagerByKlageIdUrl = (id: number) => `${Environment.REACT_APP_API_URL}/klager/klageid/${id}`;
-
-export const getKlagerByFnrUrl = (fnr: string) => `${Environment.REACT_APP_API_URL}/klager/fnr/${fnr}`;
+export const getKlageByIdUrl = (klageId: string | number): string =>
+    `${Environment.REACT_APP_API_URL}/klager/${klageId}`;
 
 export const getAddKlageUrl = (): string => `${Environment.REACT_APP_API_URL}/klager`;
 
 export const getLoginserviceRedirectUrl = (params: string) =>
     `${Environment.REACT_APP_LOGINSERVICE_URL}?redirect=${Environment.REACT_APP_URL}/klage${params}`;
 
-export const getVedleggUrl = (klageId: number, vedleggId: string) =>
+export const getVedleggUrl = (klageId: string | number, vedleggId: string) =>
     `${Environment.REACT_APP_API_URL}/klager/${klageId}/vedlegg/${vedleggId}`;
 
-export const getAddVedleggUrl = (id: number) => `${Environment.REACT_APP_API_URL}/klager/${id}/vedlegg`;
+export const getAddVedleggUrl = (klageId: string | number) =>
+    `${Environment.REACT_APP_API_URL}/klager/${klageId}/vedlegg`;
 
-export const getDeleteVedleggUrl = (klageId: number, vedleggId: string) =>
+export const getDeleteVedleggUrl = (klageId: string | number, vedleggId: string | number) =>
     `${Environment.REACT_APP_API_URL}/klager/${klageId}/vedlegg/${vedleggId}`;
 
-export const getFinalizeKlageUrl = (klageId: number) => `${Environment.REACT_APP_API_URL}/klager/${klageId}/finalize`;
+export const getFinalizeKlageUrl = (klageId: string | number) =>
+    `${Environment.REACT_APP_API_URL}/klager/${klageId}/finalize`;
 
-export const getKlageJournalpostIdUrl = (klageId: number) =>
+export const getKlageJournalpostIdUrl = (klageId: string | number) =>
     `${Environment.REACT_APP_API_URL}/klager/${klageId}/journalpostid`;
 
-export const getKlagePdfUrl = (klageId: number) => `${Environment.REACT_APP_API_URL}/klager/${klageId}/pdf`;
+export const getKlagePdfUrl = (klageId: string | number) => `${Environment.REACT_APP_API_URL}/klager/${klageId}/pdf`;
 
 export const getTemaObjectUrl = (klageKode: string) => `${Environment.REACT_APP_API_URL}/temaer/${klageKode}`;

--- a/src/components/kvittering/kvittering.tsx
+++ b/src/components/kvittering/kvittering.tsx
@@ -14,7 +14,7 @@ import Lenke from 'nav-frontend-lenker';
 import { isoDateToPretty } from '../../utils/date';
 
 interface Props {
-    klageId: number;
+    klageId: string | number;
     journalPostId: string;
     success: boolean;
     finalizedDate: string;

--- a/src/pages/kvittering/kvittering-page.tsx
+++ b/src/pages/kvittering/kvittering-page.tsx
@@ -29,7 +29,7 @@ const KvitteringPage = (props: RouteComponentProps<{}, StaticContext, FinalizedK
             waitingJoark = false;
         }, 15000);
 
-        const waitForJournalpostId = (klageId: number) => {
+        const waitForJournalpostId = (klageId: string | number) => {
             getJournalpostId(klageId)
                 .then(response => {
                     if (response === '') {

--- a/src/services/fileService.tsx
+++ b/src/services/fileService.tsx
@@ -1,7 +1,8 @@
 import * as baseService from './baseService';
 import { getAddVedleggUrl, getDeleteVedleggUrl } from '../clients/apiUrls';
 
-export const addVedleggToKlage = (id: number, vedlegg: File) => baseService.postVedlegg(getAddVedleggUrl(id), vedlegg);
+export const addVedleggToKlage = (klageId: string | number, vedlegg: File) =>
+    baseService.postVedlegg(getAddVedleggUrl(klageId), vedlegg);
 
-export const deleteVedlegg = (klageID: number, vedleggID: number | string) =>
-    baseService.deleteVedlegg(getDeleteVedleggUrl(klageID, vedleggID.toString()));
+export const deleteVedlegg = (klageID: string | number, vedleggID: number | string) =>
+    baseService.deleteVedlegg(getDeleteVedleggUrl(klageID, vedleggID));

--- a/src/services/klageService.tsx
+++ b/src/services/klageService.tsx
@@ -15,11 +15,13 @@ export const postKlage = (klage: KlageDraft) => baseService.postKlage(getAddKlag
 
 export const putKlage = (klage: Klage) => baseService.putKlage(getKlageByIdUrl(klage.id), klage);
 
-export const getKlage = (klageId: string) => baseService.get<Klage>(getKlageByIdUrl(klageId));
+export const getKlage = (klageId: string | number) => baseService.get<Klage>(getKlageByIdUrl(klageId));
 
-export const finalizeKlage = (klageId: number) => baseService.post<FinalizedKlage>(getFinalizeKlageUrl(klageId));
+export const finalizeKlage = (klageId: string | number) =>
+    baseService.post<FinalizedKlage>(getFinalizeKlageUrl(klageId));
 
-export const getJournalpostId = (klageId: number) => baseService.get<string>(getKlageJournalpostIdUrl(klageId));
+export const getJournalpostId = (klageId: string | number) =>
+    baseService.get<string>(getKlageJournalpostIdUrl(klageId));
 
 export const getTemaObject = (temaKode: string) => baseService.get<TemaObject>(getTemaObjectUrl(temaKode));
 

--- a/src/types/klage.tsx
+++ b/src/types/klage.tsx
@@ -14,11 +14,11 @@ export interface KlageDraft {
 }
 
 export interface Klage extends KlageDraft {
-    readonly id: number;
+    readonly id: string | number;
 }
 
 export interface KlageSkjema {
-    id: number | null;
+    id: string | null;
     fritekst: string;
     tema: string;
     ytelse: string;
@@ -41,11 +41,11 @@ export const klageSkjemaToKlageDraft = (klageSkjema: KlageSkjema): KlageDraft =>
 });
 
 export const klageSkjemaToKlage = (klageSkjema: KlageSkjema): Klage => {
-    if (klageSkjema.id === null) {
-        throw new Error("KlageSkjema is missing required property 'id'. Did you mean to create a draft?");
+    if (klageSkjema.id === null || klageSkjema.id.length === 0) {
+        throw new Error('KlageSkjema is missing required property "id". Did you mean to create a draft?');
     }
     return {
-        id: klageSkjema.id,
+        id: ensureInt(klageSkjema.id),
         fritekst: klageSkjema.fritekst,
         tema: klageSkjema.tema,
         ytelse: klageSkjema.ytelse,
@@ -57,10 +57,20 @@ export const klageSkjemaToKlage = (klageSkjema: KlageSkjema): Klage => {
     };
 };
 
+const ensureInt = (klageId: string): number => {
+    const parsed = Number.parseInt(klageId, 10);
+    if (Number.isNaN(parsed)) {
+        throw new Error(
+            `KlageSkjema property "id" is not parsable to an integer. Expected string parsable to integer, got "${klageId}".`
+        );
+    }
+    return parsed;
+};
+
 export const klageToKlageSkjema = (klage: Klage): KlageSkjema => {
     const { isoDate, dateChoice } = parseVedtakText(klage.vedtak);
     return {
-        id: klage.id,
+        id: klage.id.toString(),
         fritekst: klage.fritekst,
         tema: klage.tema,
         ytelse: klage.ytelse,


### PR DESCRIPTION
I forberedelse til at klage IDer blir gjort om til `UUID` fra `Int`, som vil være `string` i frontend endres koden til å håndtere klage IDer som både `string` og `number`.

Union types mellom `string | number` og kode som konverterer mellom `string` og `number` skal fjernes etter backend har endret IDer til `string` (ikke nødvendigvis `UUID`).

https://trello.com/c/U5RffRDH/156-endre-klage-id-til-uuid