### PR TITLE
Allow nav.no as outbound host

### DIFF
--- a/nais/dev.json
+++ b/nais/dev.json
@@ -1,5 +1,6 @@
 {
     "ingresses": ["https://klage-dittnav.dev.nav.no"],
+    "externals": ["dekoratoren.dev.nav.no"],
     "env": {
         "REACT_APP_URL": "https://klage-dittnav.dev.nav.no",
         "REACT_API_URL": "https://klage-dittnav-api.dev.nav.no",

--- a/nais/nais.yaml
+++ b/nais/nais.yaml
@@ -30,3 +30,9 @@ spec:
        - name: {{@key}}
          value: "{{this}}"
     {{/each}}
+  accessPolicy:
+    outbound:
+      external:
+        {{#each externals as |host|}}
+        - host: {{host}}
+        {{/each}}

--- a/nais/prod.json
+++ b/nais/prod.json
@@ -1,12 +1,11 @@
 {
-  "ingresses": [
-    "https://klage-dittnav.nav.no"
-  ],
-  "env": {
-    "REACT_APP_URL": "https://klage-dittnav.nav.no",
-    "REACT_API_URL": "https://klage-dittnav-api.nav.no",
-    "REACT_APP_LOGINSERVICE_URL": "https://loginservice.nav.no/login",
-    "FRONTENDLOGGER_BASE_URL": "https://www.nav.no/frontendlogger",
-    "REACT_APP_MOCK_DATA": false
-  }
+    "ingresses": ["https://klage-dittnav.nav.no"],
+    "externals": ["www.nav.no"],
+    "env": {
+        "REACT_APP_URL": "https://klage-dittnav.nav.no",
+        "REACT_API_URL": "https://klage-dittnav-api.nav.no",
+        "REACT_APP_LOGINSERVICE_URL": "https://loginservice.nav.no/login",
+        "FRONTENDLOGGER_BASE_URL": "https://www.nav.no/frontendlogger",
+        "REACT_APP_MOCK_DATA": false
+    }
 }


### PR DESCRIPTION
Whiteliste nav.no for å kunne hente Dekoratøren.
Prod og dev er nede inntil dette er merget og deployet.