### PR TITLE
Make NAV links render React Router links

### DIFF
--- a/src/components/klage-eller-anke/klage-eller-anke-innsending.tsx
+++ b/src/components/klage-eller-anke/klage-eller-anke-innsending.tsx
@@ -10,6 +10,7 @@ import MobilePhone from '../../assets/images/icons/MobilePhone';
 import { RouteComponentProps } from 'react-router-dom';
 import { getKategori, hasDigitalForm } from '../../data/klage-eller-anke-temaer';
 import NotFoundPage from '../../pages/not-found/not-found-page';
+import KlageLinkPanel from '../link/link';
 
 interface MatchParams {
     kategori: string;
@@ -99,7 +100,7 @@ const DigitalContent = (props: DigitalContentProps) => {
     }
     return (
         <MarginContainer>
-            <LenkepanelBase href={'https://klage-dittnav.nav.no/klage?tema=' + props.tema} border>
+            <KlageLinkPanel href={'/klage?tema=' + props.tema} border>
                 <div className="lenkepanel-content-with-image">
                     <div className="icon-container">
                         <MobilePhone />
@@ -111,7 +112,7 @@ const DigitalContent = (props: DigitalContentProps) => {
                         </MarginTopContainer>
                     </div>
                 </div>
-            </LenkepanelBase>
+            </KlageLinkPanel>
             <Lenke
                 target="_blank"
                 rel="noopener noreferrer"

--- a/src/components/klage-eller-anke/klage-eller-anke-tema.tsx
+++ b/src/components/klage-eller-anke/klage-eller-anke-tema.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Systemtittel, Normaltekst, Sidetittel, Undertittel } from 'nav-frontend-typografi';
-import { LenkepanelBase } from 'nav-frontend-lenkepanel';
 import { KLAGE_ELLER_ANKE_TEMAER } from '../../data/klage-eller-anke-temaer';
 import {
     Margin40Container,
@@ -9,6 +8,7 @@ import {
 } from '../../styled-components/main-styled-components';
 import Veilederpanel from 'nav-frontend-veilederpanel';
 import VeilederIcon from '../../assets/Veileder.svg';
+import KlageLinkPanel from '../link/link';
 
 const KlageEllerAnkeTema = () => (
     <section>
@@ -37,12 +37,12 @@ const KlageEllerAnkeTema = () => (
 
 const getLinks = () =>
     KLAGE_ELLER_ANKE_TEMAER.map(tema => (
-        <LenkepanelBase key={tema.tittel} href={`klage-anke/${tema.path}`} className="lenkepanel-flex" border>
+        <KlageLinkPanel key={tema.tittel} href={`klage-anke/${tema.path}`} className="lenkepanel-flex" border>
             <div>
                 <Undertittel className="lenkepanel__heading">{tema.tittel}</Undertittel>
                 <Normaltekst>{tema.beskrivelse}</Normaltekst>
             </div>
-        </LenkepanelBase>
+        </KlageLinkPanel>
     ));
 
 export default KlageEllerAnkeTema;

--- a/src/components/klage-eller-anke/klage-eller-anke-ytelse.tsx
+++ b/src/components/klage-eller-anke/klage-eller-anke-ytelse.tsx
@@ -6,9 +6,9 @@ import {
     Margin40TopContainer,
     PointsFlexListContainer
 } from '../../styled-components/main-styled-components';
-import { LenkepanelBase } from 'nav-frontend-lenkepanel';
 import { RouteComponentProps } from 'react-router-dom';
 import NotFoundPage from '../../pages/not-found/not-found-page';
+import KlageLinkPanel from '../link/link';
 
 interface MatchParams {
     kategori: string;
@@ -41,11 +41,11 @@ const KlageEllerAnkeYtelse = (props: Props) => {
 
 const getLinks = (kategori: string, underkategorier: KategoriTema[]) =>
     underkategorier.map(tema => (
-        <LenkepanelBase key={tema.tittel} href={`${kategori}/${tema.tema}`} className="lenkepanel-flex" border>
+        <KlageLinkPanel key={tema.tittel} href={`${kategori}/${tema.tema}`} className="lenkepanel-flex" border>
             <div>
                 <Undertittel className="lenkepanel__heading">{tema.tittel}</Undertittel>
             </div>
-        </LenkepanelBase>
+        </KlageLinkPanel>
     ));
 
 export default KlageEllerAnkeYtelse;

--- a/src/components/link/link.tsx
+++ b/src/components/link/link.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { LenkepanelBase } from 'nav-frontend-lenkepanel';
+import { Link } from 'react-router-dom';
+
+export interface KlageLinkProps {
+    className?: string;
+    href: string; // Sent as prop to the linkCreator function.
+    children: React.ReactNode | React.ReactNode[];
+    border?: boolean;
+}
+
+const KlageLinkPanel = (props: KlageLinkProps) => (
+    <LenkepanelBase href={props.href} className={props.className} border={props.border} linkCreator={RouterLink}>
+        {props.children}
+    </LenkepanelBase>
+);
+
+const RouterLink = (props: React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+    <Link {...props} to={props.href ?? ''}>
+        {props.children}
+    </Link>
+);
+
+export default KlageLinkPanel;


### PR DESCRIPTION
Lenker for den nye skjemavelgeren var normale lenker, dvs. at nettleseren navigerte til sidene ved å laste hele siden på nytt.
Siden dette er en SPA (Singe Page Application) bør vi bruke `history.pushState()` for å navigere innenfor applikasjonen.
Denne PRen gjør følgende endring:

- Oppretter ny komponent `KlageLinkPanel` som bygger på `LenkepanelBase`.
- Bytter ut all bruk av `LenkepanelBase` med `KlageLinkPanel`.

`KlageLinkPanel` brukes helt likt som `LenkepanelBase`, men setter `linkCreator`-funksjonen til å være en React Router lenke i stedet for en HTML a-tag, som er default.

Følgen av denne endringen er drastisk raskere lasting av sider (unntatt initial load selvfølgelig).