### PR TITLE
Inngang ytelse url

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
         "docker-rmi": "npm run docker-kill && docker rmi klage-dittnav",
         "start": "npm-run-all -p start:*",
         "build": "npm-run-all -p build:*",
-        "test": "react-scripts test",
+        "test": "react-scripts test --verbose",
         "eject": "react-scripts eject",
         "prettier": "prettier --write src/**/*.{tsx,ts,less}"
     },

--- a/src/components/form-landing/form-landing.tsx
+++ b/src/components/form-landing/form-landing.tsx
@@ -112,57 +112,6 @@ const FormLanding = (props: Props) => {
         setTemaNotSet(chosenTema === null);
     }, [dispatch, props.location.search, props.location.pathname, props.query, chosenTema, klageId, activeKlage]);
 
-    useEffect(() => {
-        const { klageId, tema, ytelse, saksnummer } = getResumeState(
-            props.location.search,
-            sessionStorage,
-            props.location.pathname
-        );
-        setStorageContent(klageId, tema, ytelse, saksnummer);
-
-        if (ytelse !== null) {
-            dispatch(setValgtYtelse(ytelse));
-        }
-        if (tema !== null) {
-            dispatch(setValgtTema(tema));
-        }
-
-        if (klageId !== null) {
-            dispatch(setKlageId(klageId));
-            setIsLoading(false);
-        } else if (ytelse !== null && tema !== null) {
-            const klageSkjema: KlageSkjema = {
-                id: null,
-                ytelse,
-                tema,
-                saksnummer: saksnummer,
-                datoalternativ: DatoValg.INGEN,
-                vedtak: null,
-                fritekst: '',
-                vedlegg: [],
-                referrer: getReferrer()
-            };
-            dispatch(postNewKlage(klageSkjema));
-            setIsLoading(false);
-        } else if (tema !== null) {
-            getTemaObject(tema)
-                .then(temaObject => {
-                    dispatch(setValgtYtelse(ytelse ?? temaObject.value));
-                    setIsLoading(false);
-                })
-                .catch((err: AxiosError) => {
-                    if (err.response?.status === 404) {
-                        setErrorState(true);
-                        setIsLoading(false);
-                        return;
-                    }
-                    logError(err);
-                });
-        } else {
-            setIsLoading(false);
-        }
-    }, [dispatch, props.location.search, props.location.pathname]);
-
     logInfo('Form landing page visited.', { chosenYtelse: chosenYtelse, referrer: document.referrer });
 
     if (loading || isLoadingDraft) {

--- a/src/components/klage-eller-anke/klage-eller-anke-innsending.test.tsx
+++ b/src/components/klage-eller-anke/klage-eller-anke-innsending.test.tsx
@@ -1,0 +1,71 @@
+import { getKategori, getUnderkategoriTitleFromPath, ytelseInTema } from '../../data/klage-eller-anke-temaer';
+
+describe('Formatting in root page', () => {
+    it('Should get category object from category path', () => {
+        const expectedKategoriObj = {
+            tittel: 'Familie og barn',
+            path: 'familie-og-barn',
+            beskrivelse: 'Barnetrygd, foreldrepenger, pleie',
+            underkategorier: [
+                {
+                    tema: 'FOR',
+                    tittel: 'Foreldrepenger, engangsstønad og svangerskapspenger',
+                    ytelsePath: 'foreldrepenger-engangsstønad-svangerskapspenger',
+                    skjemaveileder: false,
+                    digital: true,
+                    bareAnke: false
+                }
+            ]
+        };
+        const kategoriObj = getKategori('familie-og-barn');
+        expect(kategoriObj).toStrictEqual(expectedKategoriObj);
+    });
+
+    it('Should return false if cant find title of underkategori from path', () => {
+        const kategoriObj = {
+            tittel: 'Arbeid',
+            path: 'arbeid',
+            beskrivelse: 'Dagpenger, AAP, egen bedrift',
+            underkategorier: [
+                {
+                    tema: 'FOR',
+                    tittel: 'Foreldrepenger, engangsstønad og svangerskapspenger',
+                    ytelsePath: 'foreldrepenger-engangsstønad-svangerskapspenger',
+                    skjemaveileder: false,
+                    digital: true,
+                    bareAnke: false
+                }
+            ]
+        };
+        const ytelse = 'foreldrepenger-engangsstønad-test';
+
+        const expectedResult = false;
+
+        const result = ytelseInTema(kategoriObj, 'FOR', ytelse);
+
+        expect(result).toStrictEqual(expectedResult);
+    });
+
+    it('Should get title of underkategori from path', () => {
+        const kategoriObj = {
+            tittel: 'Arbeid',
+            path: 'arbeid',
+            beskrivelse: 'Dagpenger, AAP, egen bedrift',
+            underkategorier: [
+                {
+                    tema: 'FOR',
+                    tittel: 'Foreldrepenger, engangsstønad og svangerskapspenger',
+                    ytelsePath: 'foreldrepenger-engangsstønad-svangerskapspenger',
+                    skjemaveileder: false,
+                    digital: true,
+                    bareAnke: false
+                }
+            ]
+        };
+        const ytelse = 'foreldrepenger-engangsstønad-svangerskapspenger';
+        const expectedYtelseTitle = 'Foreldrepenger, engangsstønad og svangerskapspenger';
+
+        const underkategoriTitle = getUnderkategoriTitleFromPath(kategoriObj, ytelse);
+        expect(underkategoriTitle).toStrictEqual(expectedYtelseTitle);
+    });
+});

--- a/src/components/klage-eller-anke/klage-eller-anke-innsending.test.tsx
+++ b/src/components/klage-eller-anke/klage-eller-anke-innsending.test.tsx
@@ -6,11 +6,11 @@ describe('Formatting in root page', () => {
             tittel: 'Familie og barn',
             path: 'familie-og-barn',
             beskrivelse: 'Barnetrygd, foreldrepenger, pleie',
-            underkategorier: [
+            ytelser: [
                 {
-                    tema: 'FOR',
                     tittel: 'Foreldrepenger, engangsstønad og svangerskapspenger',
-                    ytelsePath: 'foreldrepenger-engangsstønad-svangerskapspenger',
+                    path: 'foreldrepenger-engangsstønad-svangerskapspenger',
+                    temakode: 'FOR',
                     skjemaveileder: false,
                     digital: true,
                     bareAnke: false
@@ -26,11 +26,11 @@ describe('Formatting in root page', () => {
             tittel: 'Arbeid',
             path: 'arbeid',
             beskrivelse: 'Dagpenger, AAP, egen bedrift',
-            underkategorier: [
+            ytelser: [
                 {
-                    tema: 'FOR',
                     tittel: 'Foreldrepenger, engangsstønad og svangerskapspenger',
-                    ytelsePath: 'foreldrepenger-engangsstønad-svangerskapspenger',
+                    path: 'foreldrepenger-engangsstønad-svangerskapspenger',
+                    temakode: 'FOR',
                     skjemaveileder: false,
                     digital: true,
                     bareAnke: false
@@ -51,11 +51,11 @@ describe('Formatting in root page', () => {
             tittel: 'Arbeid',
             path: 'arbeid',
             beskrivelse: 'Dagpenger, AAP, egen bedrift',
-            underkategorier: [
+            ytelser: [
                 {
-                    tema: 'FOR',
                     tittel: 'Foreldrepenger, engangsstønad og svangerskapspenger',
-                    ytelsePath: 'foreldrepenger-engangsstønad-svangerskapspenger',
+                    path: 'foreldrepenger-engangsstønad-svangerskapspenger',
+                    temakode: 'FOR',
                     skjemaveileder: false,
                     digital: true,
                     bareAnke: false

--- a/src/components/klage-eller-anke/klage-eller-anke-innsending.tsx
+++ b/src/components/klage-eller-anke/klage-eller-anke-innsending.tsx
@@ -3,44 +3,48 @@ import React from 'react';
 import BookWithShield from '../../assets/images/icons/BookWithShield';
 import LetterOpened from '../../assets/images/icons/LetterOpened';
 import { Margin40Container, MarginContainer, MarginTopContainer } from '../../styled-components/main-styled-components';
-import { ensureStringIsTema, Tema, TemaKey } from '../../types/tema';
+import { ensureStringIsTema, TemaKey } from '../../types/tema';
 import { LenkepanelBase } from 'nav-frontend-lenkepanel';
 import Lenke from 'nav-frontend-lenker';
 import MobilePhone from '../../assets/images/icons/MobilePhone';
 import { RouteComponentProps } from 'react-router-dom';
-import { getKategori, hasDigitalForm } from '../../data/klage-eller-anke-temaer';
+import {
+    getKategori,
+    getUnderkategoriTitleFromPath,
+    hasDigitalForm,
+    ytelseInTema
+} from '../../data/klage-eller-anke-temaer';
 import NotFoundPage from '../../pages/not-found/not-found-page';
 import KlageLinkPanel from '../link/link';
 
 interface MatchParams {
     kategori: string;
     tema: string;
+    ytelse: string;
 }
 
 interface Props extends RouteComponentProps<MatchParams> {}
 
 const KlageEllerAnkeInnsending = (props: Props) => {
-    const kategori = getKategori(props.match.params.kategori);
-    if (kategori === null) {
-        return <NotFoundPage />;
-    }
-
+    const kategoriObj = getKategori(props.match.params.kategori);
     const tema = ensureStringIsTema(props.match.params.tema);
-    if (tema === null) {
+    const ytelse = props.match.params.ytelse;
+
+    if (kategoriObj === null || tema === null || ytelse === null || !ytelseInTema(kategoriObj, tema, ytelse)) {
         return <NotFoundPage />;
     }
 
-    const isDigital = hasDigitalForm(kategori, tema);
+    const ytelseTitle = getUnderkategoriTitleFromPath(kategoriObj, ytelse);
 
-    const ytelse = Tema[tema];
+    const isDigital = hasDigitalForm(kategoriObj, tema);
 
     return (
         <div>
-            <Sidetittel>{ytelse}</Sidetittel>
+            <Sidetittel>{ytelseTitle}</Sidetittel>
             <Margin40Container>
                 <Intro isDigital />
             </Margin40Container>
-            <DigitalContent isDigital={isDigital} tema={tema} />
+            <DigitalContent isDigital={isDigital} tema={tema} ytelse={ytelse} />
             <Margin40Container>
                 <LenkepanelBase href="#" border>
                     <div className="lenkepanel-content-with-image">
@@ -92,6 +96,7 @@ const KlageEllerAnkeInnsending = (props: Props) => {
 interface DigitalContentProps {
     isDigital: boolean;
     tema: TemaKey;
+    ytelse: string;
 }
 
 const DigitalContent = (props: DigitalContentProps) => {
@@ -100,7 +105,7 @@ const DigitalContent = (props: DigitalContentProps) => {
     }
     return (
         <MarginContainer>
-            <KlageLinkPanel href={'/klage?tema=' + props.tema} border>
+            <KlageLinkPanel href={'/klage?tema=' + props.tema + '&ytelse=' + props.ytelse} border>
                 <div className="lenkepanel-content-with-image">
                     <div className="icon-container">
                         <MobilePhone />

--- a/src/components/klage-eller-anke/klage-eller-anke-innsending.tsx
+++ b/src/components/klage-eller-anke/klage-eller-anke-innsending.tsx
@@ -44,7 +44,7 @@ const KlageEllerAnkeInnsending = (props: Props) => {
             <Margin40Container>
                 <Intro isDigital />
             </Margin40Container>
-            <DigitalContent isDigital={isDigital} tema={tema} ytelse={ytelse} />
+            <DigitalContent isDigital={isDigital} tema={tema} ytelse={ytelseTitle} />
             <Margin40Container>
                 <LenkepanelBase href="#" border>
                     <div className="lenkepanel-content-with-image">
@@ -96,16 +96,22 @@ const KlageEllerAnkeInnsending = (props: Props) => {
 interface DigitalContentProps {
     isDigital: boolean;
     tema: TemaKey;
-    ytelse: string;
+    ytelse: string | null;
 }
 
 const DigitalContent = (props: DigitalContentProps) => {
     if (!props.isDigital) {
         return null;
     }
+
+    let redirectUrl = '/klage?tema=' + props.tema;
+    if (props.ytelse !== null) {
+        redirectUrl += '&ytelse=' + props.ytelse;
+    }
+
     return (
         <MarginContainer>
-            <KlageLinkPanel href={'/klage?tema=' + props.tema + '&ytelse=' + props.ytelse} border>
+            <KlageLinkPanel href={redirectUrl} border>
                 <div className="lenkepanel-content-with-image">
                     <div className="icon-container">
                         <MobilePhone />

--- a/src/components/klage-eller-anke/klage-eller-anke-tema.tsx
+++ b/src/components/klage-eller-anke/klage-eller-anke-tema.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Systemtittel, Normaltekst, Sidetittel, Undertittel } from 'nav-frontend-typografi';
-import { KLAGE_ELLER_ANKE_TEMAER } from '../../data/klage-eller-anke-temaer';
+import { INNGANG_KATEGORIER } from '../../data/klage-eller-anke-temaer';
 import {
     Margin40Container,
     Margin40TopContainer,
@@ -31,12 +31,12 @@ const KlageEllerAnkeTema = () => (
                 <Systemtittel>Hvilket tema gjelder det?</Systemtittel>
             </Margin40Container>
         </div>
-        <PointsFlexListContainer>{getLinks()}</PointsFlexListContainer>
+        <PointsFlexListContainer>{getLinkPanels()}</PointsFlexListContainer>
     </section>
 );
 
-const getLinks = () =>
-    KLAGE_ELLER_ANKE_TEMAER.map(tema => (
+const getLinkPanels = () =>
+    INNGANG_KATEGORIER.map(tema => (
         <KlageLinkPanel key={tema.tittel} href={`${tema.path}`} className="lenkepanel-flex" border>
             <div>
                 <Undertittel className="lenkepanel__heading">{tema.tittel}</Undertittel>

--- a/src/components/klage-eller-anke/klage-eller-anke-ytelse.tsx
+++ b/src/components/klage-eller-anke/klage-eller-anke-ytelse.tsx
@@ -40,10 +40,15 @@ const KlageEllerAnkeYtelse = (props: Props) => {
 };
 
 const getLinks = (kategori: string, underkategorier: KategoriTema[]) =>
-    underkategorier.map(tema => (
-        <KlageLinkPanel key={tema.tittel} href={`${kategori}/${tema.tema}`} className="lenkepanel-flex" border>
+    underkategorier.map(underkategori => (
+        <KlageLinkPanel
+            key={underkategori.tittel}
+            href={`${kategori}/${underkategori.tema}/${underkategori.ytelsePath}`}
+            className="lenkepanel-flex"
+            border
+        >
             <div>
-                <Undertittel className="lenkepanel__heading">{tema.tittel}</Undertittel>
+                <Undertittel className="lenkepanel__heading">{underkategori.tittel}</Undertittel>
             </div>
         </KlageLinkPanel>
     ));

--- a/src/components/klage-eller-anke/klage-eller-anke-ytelse.tsx
+++ b/src/components/klage-eller-anke/klage-eller-anke-ytelse.tsx
@@ -1,6 +1,6 @@
 import { Sidetittel, Systemtittel, Undertittel } from 'nav-frontend-typografi';
 import React from 'react';
-import { getKategori, KategoriTema } from '../../data/klage-eller-anke-temaer';
+import { getKategori, InngangYtelse } from '../../data/klage-eller-anke-temaer';
 import {
     Margin40Container,
     Margin40TopContainer,
@@ -33,17 +33,17 @@ const KlageEllerAnkeYtelse = (props: Props) => {
                 </Margin40Container>
             </div>
             <PointsFlexListContainer>
-                {getLinks(props.match.params.kategori, kategori.underkategorier)}
+                {getLinkPanels(props.match.params.kategori, kategori.ytelser)}
             </PointsFlexListContainer>
         </section>
     );
 };
 
-const getLinks = (kategori: string, underkategorier: KategoriTema[]) =>
+const getLinkPanels = (kategori: string, underkategorier: InngangYtelse[]) =>
     underkategorier.map(underkategori => (
         <KlageLinkPanel
             key={underkategori.tittel}
-            href={`${kategori}/${underkategori.tema}/${underkategori.ytelsePath}`}
+            href={`${kategori}/${underkategori.temakode}/${underkategori.path}`}
             className="lenkepanel-flex"
             border
         >

--- a/src/data/klage-eller-anke-temaer.json
+++ b/src/data/klage-eller-anke-temaer.json
@@ -1,22 +1,22 @@
 {
-    "temaer": [
+    "kategorier": [
         {
             "tittel": "Arbeid",
             "path": "arbeid",
             "beskrivelse": "Dagpenger, AAP, egen bedrift",
-            "underkategorier": [
+            "ytelser": [
                 {
-                    "tema": "AAP",
                     "tittel": "Arbeidsavklaringspenger (AAP)",
-                    "ytelsePath": "arbeidsavklaringspenger-aap",
+                    "path": "arbeidsavklaringspenger-aap",
+                    "temakode": "AAP",
                     "skjemaveileder": false,
                     "digital": false,
                     "bareAnke": false
                 },
                 {
-                    "tema": "DAG",
                     "tittel": "Dagpenger",
-                    "ytelsePath": "dagpenger",
+                    "path": "dagpenger",
+                    "temakode": "DAG",
                     "skjemaveileder": false,
                     "digital": false,
                     "bareAnke": false
@@ -27,11 +27,11 @@
             "tittel": "Familie og barn",
             "path": "familie-og-barn",
             "beskrivelse": "Barnetrygd, foreldrepenger, pleie",
-            "underkategorier": [
+            "ytelser": [
                 {
-                    "tema": "FOR",
                     "tittel": "Foreldrepenger, engangsstønad og svangerskapspenger",
-                    "ytelsePath": "foreldrepenger-engangsstønad-svangerskapspenger",
+                    "path": "foreldrepenger-engangsstønad-svangerskapspenger",
+                    "temakode": "FOR",
                     "skjemaveileder": false,
                     "digital": true,
                     "bareAnke": false

--- a/src/data/klage-eller-anke-temaer.json
+++ b/src/data/klage-eller-anke-temaer.json
@@ -8,6 +8,7 @@
                 {
                     "tema": "AAP",
                     "tittel": "Arbeidsavklaringspenger (AAP)",
+                    "ytelsePath": "arbeidsavklaringspenger-aap",
                     "skjemaveileder": false,
                     "digital": false,
                     "bareAnke": false
@@ -15,6 +16,7 @@
                 {
                     "tema": "DAG",
                     "tittel": "Dagpenger",
+                    "ytelsePath": "dagpenger",
                     "skjemaveileder": false,
                     "digital": false,
                     "bareAnke": false
@@ -29,6 +31,7 @@
                 {
                     "tema": "FOR",
                     "tittel": "Foreldrepenger, engangsstønad og svangerskapspenger",
+                    "ytelsePath": "foreldrepenger-engangsstønad-svangerskapspenger",
                     "skjemaveileder": false,
                     "digital": true,
                     "bareAnke": false

--- a/src/data/klage-eller-anke-temaer.ts
+++ b/src/data/klage-eller-anke-temaer.ts
@@ -28,11 +28,5 @@ export const ytelseInTema = (kategoriObj: InngangKategori, tema: string, ytelse:
 };
 
 export const getUnderkategoriTitleFromPath = (kategori: InngangKategori, underkategoriPath: string) => {
-    if (kategori === null) {
-        return null;
-    }
-    if (kategori.ytelser) {
-        return kategori.ytelser.find(({ path }) => path === underkategoriPath)?.tittel || '';
-    }
-    return '';
+    return kategori.ytelser.find(({ path }) => path === underkategoriPath)?.tittel || '';
 };

--- a/src/data/klage-eller-anke-temaer.ts
+++ b/src/data/klage-eller-anke-temaer.ts
@@ -3,6 +3,7 @@ import * as data from './klage-eller-anke-temaer.json';
 export interface KategoriTema {
     tema: TemaKey;
     tittel: string;
+    ytelsePath: string;
     skjemaveileder: boolean;
     digital: boolean;
     bareAnke: boolean;
@@ -21,3 +22,17 @@ export const getKategori = (kategori: string) => KLAGE_ELLER_ANKE_TEMAER.find(({
 
 export const hasDigitalForm = (kategori: KlageAnkeTema, tema: TemaKey) =>
     kategori.underkategorier.some(t => t.digital && t.tema === tema);
+
+export const ytelseInTema = (kategoriObj: KlageAnkeTema, temaKode: string, ytelse: string) => {
+    return kategoriObj.underkategorier.some(({ tema, ytelsePath }) => tema === temaKode && ytelsePath === ytelse);
+};
+
+export const getUnderkategoriTitleFromPath = (kategori: KlageAnkeTema, underkategoriPath: string) => {
+    if (kategori === null) {
+        return null;
+    }
+    if (kategori.underkategorier) {
+        return kategori.underkategorier.find(({ ytelsePath }) => ytelsePath === underkategoriPath)?.tittel || '';
+    }
+    return '';
+};

--- a/src/data/klage-eller-anke-temaer.ts
+++ b/src/data/klage-eller-anke-temaer.ts
@@ -1,38 +1,38 @@
 import { TemaKey } from '../types/tema';
 import * as data from './klage-eller-anke-temaer.json';
-export interface KategoriTema {
-    tema: TemaKey;
+export interface InngangYtelse {
     tittel: string;
-    ytelsePath: string;
+    path: string;
+    temakode: TemaKey;
     skjemaveileder: boolean;
     digital: boolean;
     bareAnke: boolean;
 }
 
-interface KlageAnkeTema {
+interface InngangKategori {
     tittel: string;
     path: string;
     beskrivelse: string;
-    underkategorier: KategoriTema[];
+    ytelser: InngangYtelse[];
 }
 
-export const KLAGE_ELLER_ANKE_TEMAER: KlageAnkeTema[] = JSON.parse(JSON.stringify(data.temaer));
+export const INNGANG_KATEGORIER: InngangKategori[] = JSON.parse(JSON.stringify(data.kategorier));
 
-export const getKategori = (kategori: string) => KLAGE_ELLER_ANKE_TEMAER.find(({ path }) => path === kategori) ?? null;
+export const getKategori = (kategori: string) => INNGANG_KATEGORIER.find(({ path }) => path === kategori) ?? null;
 
-export const hasDigitalForm = (kategori: KlageAnkeTema, tema: TemaKey) =>
-    kategori.underkategorier.some(t => t.digital && t.tema === tema);
+export const hasDigitalForm = (kategori: InngangKategori, tema: TemaKey) =>
+    kategori.ytelser.some(t => t.digital && t.temakode === tema);
 
-export const ytelseInTema = (kategoriObj: KlageAnkeTema, temaKode: string, ytelse: string) => {
-    return kategoriObj.underkategorier.some(({ tema, ytelsePath }) => tema === temaKode && ytelsePath === ytelse);
+export const ytelseInTema = (kategoriObj: InngangKategori, tema: string, ytelse: string) => {
+    return kategoriObj.ytelser.some(({ temakode, path }) => temakode === tema && path === ytelse);
 };
 
-export const getUnderkategoriTitleFromPath = (kategori: KlageAnkeTema, underkategoriPath: string) => {
+export const getUnderkategoriTitleFromPath = (kategori: InngangKategori, underkategoriPath: string) => {
     if (kategori === null) {
         return null;
     }
-    if (kategori.underkategorier) {
-        return kategori.underkategorier.find(({ ytelsePath }) => ytelsePath === underkategoriPath)?.tittel || '';
+    if (kategori.ytelser) {
+        return kategori.ytelser.find(({ path }) => path === underkategoriPath)?.tittel || '';
     }
     return '';
 };

--- a/src/utils/routes.config.tsx
+++ b/src/utils/routes.config.tsx
@@ -75,7 +75,7 @@ export const routesPages: RouteType[] = [
         exact: true
     },
     {
-        path: `/:kategori/:tema`,
+        path: `/:kategori/:tema/:ytelse`,
         component: KlageEllerAnkeInnsending,
         exact: true
     },


### PR DESCRIPTION
Bruker blir sendt til skjema med riktig tema og "ytelse" (eller tittel) gjennom inngangsløsningen.
Litt renaming in JSON-fila/andre filer for forståelsens del.

Eksempel på flyt:

https://klage-dittnav.nav.no/ ->
https://klage-dittnav.nav.no/familie-og-barn ->
https://klage-dittnav.nav.no/familie-og-barn/FOR/foreldrepenger-engangsstønad-svangerskapspenger ->
https://klage-dittnav.nav.no/klage?tema=FOR&ytelse=foreldrepenger-engangsstønad-svangerskapspenger