### PR TITLE
Make server runnable outside Docker

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,6 @@
 INLINE_RUNTIME_CHUNK=false
-REACT_APP_URL=http://localhost:3000
+REACT_APP_URL=http://localhost:8080
 REACT_APP_LOGINSERVICE_URL=https://loginservice.dev.nav.no/login
-REACT_APP_API_URL=http://localhost:7070
-REACT_APP_API_PORT=3001
+REACT_API_URL=https://klage-dittnav-api.dev.nav.no
 REACT_APP_MOCK_DATA=false
+FRONTENDLOGGER_BASE_URL=""

--- a/docker-compose.backend.yml
+++ b/docker-compose.backend.yml
@@ -11,6 +11,4 @@ services:
             REACT_APP_URL: http://localhost:8080
             REACT_APP_LOGINSERVICE_URL: https://loginservice.dev.nav.no/login
             REACT_API_URL: https://klage-dittnav-api.dev.nav.no
-            #REACT_API_URL: http://localhost:7070
-            REACT_APP_API_PORT: 7070
             REACT_APP_MOCK_DATA: 'false'

--- a/src/clients/apiUrls.tsx
+++ b/src/clients/apiUrls.tsx
@@ -1,4 +1,3 @@
-// const port = process.env.REACT_APP_API_PORT || 3001;
 import Environment from '../utils/environment';
 
 export const getUserDataUrl = () => `${Environment.REACT_APP_API_URL}/bruker`;


### PR DESCRIPTION
`.env`-filen som ligger på rotnivå i prosjektet leses av `server.js` og verdiene i filen blir satt som environment variabler.
Nøkler og verdier i denne filen matchet ikke de i `docker-componse.backend.yml`.

Denne PRen fikser dette og lar enhver, som har NodeJS og NPM pakkene i `/server`-mappen installert, kjøre serveren lokalt uten Docker. Bare kjør `node ./server.js` i `/server`-mappen.

Dette er fortsatt ikke en perfekt løsning for å kjøre prosjektet lokalt, men det er en stor forbedring ift. å måtte bygge, starte og stoppe Docker hver gang man endrer noe. Serveren må fortsatt restartes, men dette tar nå 2 sekunder i stedet for 2 minutter.

Ubrukte environment variabler har blitt slettet fra både `docker-componse.backend.yml` og `.env`.