### PR TITLE
Add pretty formatting for ISO datetime and time

### DIFF
--- a/src/utils/date.test.ts
+++ b/src/utils/date.test.ts
@@ -1,6 +1,6 @@
-import { isoDateToPretty, prettyDateToISO } from './date';
+import { isoDateTimeToPretty, isoDateToPretty, isoTimeToPretty, prettyDateToISO } from './date';
 
-describe('Dates should be pretty printed for users', () => {
+describe('ISO dates should be pretty formatted', () => {
     it('Should pretty format valid ISO dates', () => {
         const isoDate = '2020-12-31';
         const pretty = isoDateToPretty(isoDate);
@@ -10,6 +10,34 @@ describe('Dates should be pretty printed for users', () => {
     it('Should return null for invalid ISO dates', () => {
         const invalidIsoDate = 'Not a date at all.';
         const pretty = isoDateToPretty(invalidIsoDate);
+        expect(pretty).toBeNull();
+    });
+});
+
+describe('ISO times should be pretty formatted', () => {
+    it('Should pretty format valid ISO times', () => {
+        const iso = '14:25:19.734593';
+        const pretty = isoTimeToPretty(iso);
+        expect(pretty).toBe('14:25:19');
+    });
+
+    it('Should return null for invalid ISO times', () => {
+        const iso = 'Not a time at all.';
+        const pretty = isoTimeToPretty(iso);
+        expect(pretty).toBeNull();
+    });
+});
+
+describe('ISO datetimes should be pretty formatted', () => {
+    it('Should pretty format valid ISO datetimes', () => {
+        const iso = '2020-10-29T14:25:19.734593';
+        const pretty = isoDateTimeToPretty(iso);
+        expect(pretty).toBe('29.10.2020 14:25:19');
+    });
+
+    it('Should return null for invalid ISO datetimes', () => {
+        const iso = 'Not a date at all.';
+        const pretty = isoDateTimeToPretty(iso);
         expect(pretty).toBeNull();
     });
 });

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,7 +1,26 @@
-const isoRegex = /^\d{4}-\d{2}-\d{2}$/;
+const isoDateRegex = /^\d{4}-\d{2}-\d{2}$/; // 2020-10-29
+const isoTimeRegex = /^\d{2}:\d{2}:\d{2}\.\d+$/; // 14:25:19.734593
+const isoDateTimeRegex = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+$/; // 2020-10-29T14:25:19.734593
+
+export function isoDateTimeToPretty(isoDateTime: string | null): string | null {
+    if (isoDateTime === null || !isoDateTimeRegex.test(isoDateTime)) {
+        return null;
+    }
+    const [isoDate, isoTime] = isoDateTime.split('T');
+    const prettyDate = isoDateToPretty(isoDate);
+    const prettyTime = isoTimeToPretty(isoTime);
+    return `${prettyDate} ${prettyTime}`;
+}
+
+export function isoTimeToPretty(isoTime: string | null): string | null {
+    if (isoTime === null || !isoTimeRegex.test(isoTime)) {
+        return null;
+    }
+    return isoTime.split('.')[0];
+}
 
 export function isoDateToPretty(isoDate: string | null): string | null {
-    if (isoDate === null || !isoRegex.test(isoDate)) {
+    if (isoDate === null || !isoDateRegex.test(isoDate)) {
         return null;
     }
     return isoDate.split('-').reverse().join('.');


### PR DESCRIPTION
Funksjoner for å pretty formatere ISO datoer og tider.
Ikke i bruk akkurat nå, men noe vi vet kommer til å bli tatt i bruk når statussiden bli laget.

Ble laget samtidig med endringene i backend.