### PR TITLE
Add finalized date to klage

### DIFF
--- a/src/components/kvittering/kvittering.tsx
+++ b/src/components/kvittering/kvittering.tsx
@@ -11,13 +11,13 @@ import { Systemtittel, Normaltekst, Element } from 'nav-frontend-typografi';
 import { AlertStripeSuksess } from 'nav-frontend-alertstriper';
 import { getKlagePdfUrl } from '../../clients/apiUrls';
 import Lenke from 'nav-frontend-lenker';
-import { isoDateToPretty } from '../../utils/date';
+import { ISODate, isoDateToPretty } from '../../utils/date';
 
 interface Props {
     klageId: string | number;
     journalPostId: string;
     success: boolean;
-    finalizedDate: string;
+    finalizedDate: ISODate;
 }
 const Kvittering = (props: Props) => {
     window.onbeforeunload = null;

--- a/src/pages/kvittering/kvittering-page.tsx
+++ b/src/pages/kvittering/kvittering-page.tsx
@@ -13,7 +13,7 @@ const KvitteringPage = () => {
     const [success, setSuccess] = useState<boolean>(false);
     const [journalPostId, setJournalPostId] = useState<string>('');
 
-    const { activeKlage, finalizedDate } = useSelector((state: Store) => state);
+    const { activeKlage } = useSelector((state: Store) => state);
 
     useEffect(() => {
         let waitingJoark = true;
@@ -56,14 +56,14 @@ const KvitteringPage = () => {
     if (typeof activeKlage === 'undefined') {
         return <Redirect to="/" />;
     } else {
-        if (waitingForJoark || finalizedDate === null) {
+        if (waitingForJoark || activeKlage.finalizedDate === null) {
             return <KvitteringLoading informStillWorking={informStillWorking} />;
         } else {
             return (
                 <Kvittering
                     klageId={activeKlage.id}
                     journalPostId={journalPostId}
-                    finalizedDate={finalizedDate}
+                    finalizedDate={activeKlage.finalizedDate}
                     success={success}
                 />
             );

--- a/src/services/klageService.tsx
+++ b/src/services/klageService.tsx
@@ -8,6 +8,7 @@ import {
     getTemaObjectUrl
 } from '../clients/apiUrls';
 import { Klage, KlageDraft } from '../types/klage';
+import { ISODate } from '../utils/date';
 
 export const getKlager = () => baseService.get(getKlagerUrl());
 
@@ -30,5 +31,5 @@ interface TemaObject {
 }
 
 export interface FinalizedKlage {
-    finalizedDate: string;
+    finalizedDate: ISODate;
 }

--- a/src/store/reducer.ts
+++ b/src/store/reducer.ts
@@ -23,8 +23,6 @@ export interface Store {
     klageId?: string;
 
     getKlageError: boolean;
-
-    finalizedDate: string | null;
 }
 
 export const initialState: Store = {
@@ -48,9 +46,7 @@ export const initialState: Store = {
 
     activeVedlegg: [],
 
-    getKlageError: false,
-
-    finalizedDate: null
+    getKlageError: false
 };
 
 const reducer = (state = initialState, action: ActionTypes): Store => {
@@ -123,9 +119,15 @@ const reducer = (state = initialState, action: ActionTypes): Store => {
                 klageId: action.value
             };
         case 'SET_FINALIZED_DATE':
+            if (typeof state.activeKlage === 'undefined') {
+                return state;
+            }
             return {
                 ...state,
-                finalizedDate: action.value
+                activeKlage: {
+                    ...state.activeKlage,
+                    finalizedDate: action.value
+                }
             };
         case 'SET_LOADING':
             return {

--- a/src/types/klage.tsx
+++ b/src/types/klage.tsx
@@ -1,6 +1,6 @@
 import { Vedlegg } from './vedlegg';
 import { DatoValg } from '../components/begrunnelse/datoValg';
-import { isoDateToPretty, prettyDateToISO } from '../utils/date';
+import { ISODate, isoDateToPretty, prettyDateToISO } from '../utils/date';
 
 export interface KlageDraft {
     fritekst: string;
@@ -14,6 +14,7 @@ export interface KlageDraft {
 
 export interface Klage extends KlageDraft {
     readonly id: string | number;
+    readonly finalizedDate: ISODate | null;
 }
 
 export interface KlageSkjema {
@@ -49,7 +50,8 @@ export const klageSkjemaToKlage = (klageSkjema: KlageSkjema): Klage => {
         vedtak: dateToVedtakText(klageSkjema),
         saksnummer: klageSkjema.saksnummer,
         vedlegg: klageSkjema.vedlegg,
-        journalpostId: null
+        journalpostId: null,
+        finalizedDate: null
     };
 };
 
@@ -100,7 +102,7 @@ export const dateToVedtakText = (klageSkjema: KlageSkjema): string => {
 
 export interface ParsedVedtakText {
     dateChoice: DatoValg;
-    isoDate: string | null;
+    isoDate: ISODate | null;
 }
 
 const tidligereVedtakRegex = /\d{2}.\d{2}.\d{4}$/;

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -2,7 +2,14 @@ const isoDateRegex = /^\d{4}-\d{2}-\d{2}$/; // 2020-10-29
 const isoTimeRegex = /^\d{2}:\d{2}:\d{2}\.\d+$/; // 14:25:19.734593
 const isoDateTimeRegex = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+$/; // 2020-10-29T14:25:19.734593
 
-export function isoDateTimeToPretty(isoDateTime: string | null): string | null {
+export type ISODate = string;
+export type ISODateTime = string;
+export type ISOTime = string;
+export type prettyDate = string;
+export type prettyDateTime = string;
+export type prettyTime = string;
+
+export function isoDateTimeToPretty(isoDateTime: ISODateTime | null): prettyDateTime | null {
     if (isoDateTime === null || !isoDateTimeRegex.test(isoDateTime)) {
         return null;
     }
@@ -12,14 +19,14 @@ export function isoDateTimeToPretty(isoDateTime: string | null): string | null {
     return `${prettyDate} ${prettyTime}`;
 }
 
-export function isoTimeToPretty(isoTime: string | null): string | null {
+export function isoTimeToPretty(isoTime: ISOTime | null): prettyTime | null {
     if (isoTime === null || !isoTimeRegex.test(isoTime)) {
         return null;
     }
     return isoTime.split('.')[0];
 }
 
-export function isoDateToPretty(isoDate: string | null): string | null {
+export function isoDateToPretty(isoDate: ISODate | null): prettyDate | null {
     if (isoDate === null || !isoDateRegex.test(isoDate)) {
         return null;
     }
@@ -28,7 +35,7 @@ export function isoDateToPretty(isoDate: string | null): string | null {
 
 const prettyRegex = /^\d{2}.\d{2}.\d{4}$/;
 
-export function prettyDateToISO(prettyDate: string | null): string | null {
+export function prettyDateToISO(prettyDate: prettyDate | null): ISODate | null {
     if (prettyDate === null || !prettyRegex.test(prettyDate)) {
         return null;
     }


### PR DESCRIPTION
Legger til/flytter `finalizedDate` til `Klage`.

**Hvorfor?**
- Holde typen i synk med backend.
  - Status og modified er også lagt til i backend, men får sine egne PR i frontend også.
- Gjør frontend klar for andre planlagte endringer.