### PR TITLE
Bruk grå bakgrunn på inngangen, og hvit i skjemaet

### DIFF
--- a/src/__snapshots__/App.test.tsx.snap
+++ b/src/__snapshots__/App.test.tsx.snap
@@ -2,21 +2,27 @@
 
 exports[`Welcome klage Renders correctly when there is no data 1`] = `
 <div
-  className="sc-AxjAm iJhWxX"
+  className="sc-fzqNqU feqdTo"
 >
   <div
-    className="sc-fznZeY sc-fzokOt kkKxji"
+    className="sc-AxjAm iJhWxX"
   >
-    <section>
-      <div>
+    <div
+      className="sc-fznZeY sc-fzokOt kkKxji"
+    >
+      <section>
         <div
           className="sc-AxgMl sc-fzozJi ycSJu"
         >
-          <h1
-            className="typo-sidetittel"
+          <div
+            className="sc-fzoiQi gSdsvP"
           >
-            Klage eller anke på vedtak
-          </h1>
+            <h1
+              className="typo-sidetittel"
+            >
+              Klage eller anke på vedtak
+            </h1>
+          </div>
         </div>
         <div
           className="sc-AxgMl sc-fzozJi ycSJu"
@@ -50,60 +56,68 @@ exports[`Welcome klage Renders correctly when there is no data 1`] = `
         <div
           className="sc-AxheI sc-fzoLsD ghDDDu"
         >
-          <h2
-            className="typo-systemtittel"
+          <div
+            className="sc-fznWqX gqkuZX"
           >
-            Hvilket tema gjelder det?
-          </h2>
+            <h2
+              className="typo-systemtittel"
+            >
+              Hvilket område gjelder det?
+            </h2>
+            <div
+              className="sc-AxgMl sc-fzozJi ycSJu"
+            >
+              <div
+                className="sc-fzqNJr sc-fznxsB jjiZDc"
+              >
+                <a
+                  className="lenkepanel lenkepanel-flex lenkepanel--border"
+                  href="/arbeid"
+                  onClick={[Function]}
+                >
+                  <div>
+                    <h2
+                      className="typo-undertittel lenkepanel__heading"
+                    >
+                      Arbeid
+                    </h2>
+                    <p
+                      className="typo-normal"
+                    >
+                      Dagpenger, AAP, egen bedrift
+                    </p>
+                  </div>
+                  <span
+                    className="lenkepanel__indikator"
+                  />
+                </a>
+                <a
+                  className="lenkepanel lenkepanel-flex lenkepanel--border"
+                  href="/familie-og-barn"
+                  onClick={[Function]}
+                >
+                  <div>
+                    <h2
+                      className="typo-undertittel lenkepanel__heading"
+                    >
+                      Familie og barn
+                    </h2>
+                    <p
+                      className="typo-normal"
+                    >
+                      Barnetrygd, foreldrepenger, pleie
+                    </p>
+                  </div>
+                  <span
+                    className="lenkepanel__indikator"
+                  />
+                </a>
+              </div>
+            </div>
+          </div>
         </div>
-      </div>
-      <div
-        className="sc-fzqNJr sc-fznxsB jjiZDc"
-      >
-        <a
-          className="lenkepanel lenkepanel-flex lenkepanel--border"
-          href="/arbeid"
-          onClick={[Function]}
-        >
-          <div>
-            <h2
-              className="typo-undertittel lenkepanel__heading"
-            >
-              Arbeid
-            </h2>
-            <p
-              className="typo-normal"
-            >
-              Dagpenger, AAP, egen bedrift
-            </p>
-          </div>
-          <span
-            className="lenkepanel__indikator"
-          />
-        </a>
-        <a
-          className="lenkepanel lenkepanel-flex lenkepanel--border"
-          href="/familie-og-barn"
-          onClick={[Function]}
-        >
-          <div>
-            <h2
-              className="typo-undertittel lenkepanel__heading"
-            >
-              Familie og barn
-            </h2>
-            <p
-              className="typo-normal"
-            >
-              Barnetrygd, foreldrepenger, pleie
-            </p>
-          </div>
-          <span
-            className="lenkepanel__indikator"
-          />
-        </a>
-      </div>
-    </section>
+      </section>
+    </div>
   </div>
 </div>
 `;

--- a/src/components/general/layout.tsx
+++ b/src/components/general/layout.tsx
@@ -1,14 +1,33 @@
 import React from 'react';
+import { useLocation } from 'react-router-dom';
+import styled from 'styled-components';
 import { MasterPaddingContainer, MainContainer } from '../../styled-components/main-styled-components';
+import { pathIsPartOfInngang } from '../../utils/routes.config';
 
 interface Props {
     children: React.ReactChild | React.ReactChildren;
 }
 
-const Layout = ({ children }: Props) => (
-    <MainContainer>
-        <MasterPaddingContainer>{children}</MasterPaddingContainer>
-    </MainContainer>
-);
+const Layout = ({ children }: Props) => {
+    const location = useLocation();
+    const isPartOfInngang = pathIsPartOfInngang(location.pathname);
+
+    const bgColorChooser = () => {
+        if (isPartOfInngang) return '#e7e9e9';
+        return '#fff';
+    };
+
+    const Frame = styled.div<Props>`
+        background-color: ${bgColorChooser()};
+    `;
+
+    return (
+        <Frame>
+            <MainContainer>
+                <MasterPaddingContainer>{children}</MasterPaddingContainer>
+            </MainContainer>
+        </Frame>
+    );
+};
 
 export default Layout;

--- a/src/components/inngang/inngang-hovedkategorier.tsx
+++ b/src/components/inngang/inngang-hovedkategorier.tsx
@@ -2,9 +2,11 @@ import React from 'react';
 import { Systemtittel, Normaltekst, Sidetittel, Undertittel } from 'nav-frontend-typografi';
 import { INNGANG_KATEGORIER } from '../../data/kategorier';
 import {
+    CenterInMobileContainer,
     Margin40Container,
     Margin40TopContainer,
-    PointsFlexListContainer
+    PointsFlexListContainer,
+    WhiteBackgroundContainer
 } from '../../styled-components/main-styled-components';
 import Veilederpanel from 'nav-frontend-veilederpanel';
 import VeilederIcon from '../../assets/Veileder.svg';
@@ -16,26 +18,31 @@ const InngangHovedkategorier = () => {
     useLogPageView(PageIdentifier.INNGANG_HOVEDKATEGORIER);
     return (
         <section>
-            <div>
-                <Margin40TopContainer>
+            <Margin40TopContainer>
+                <CenterInMobileContainer>
                     <Sidetittel>Klage eller anke på vedtak</Sidetittel>
-                </Margin40TopContainer>
+                </CenterInMobileContainer>
+            </Margin40TopContainer>
 
-                <Margin40TopContainer>
-                    <Veilederpanel type={'plakat'} kompakt svg={<img src={VeilederIcon} alt="Veileder" />}>
-                        <Normaltekst>
-                            Hvis NAV har behandlet en sak som gjelder deg og du er uenig i vedtaket, har du flere
-                            valgmuligheter for å belyse saken bedre og få en ny vurdering. Start med å velge hvilket
-                            tema saken gjelder. Du finner denne informasjonen i vedtaket som du har mottatt fra NAV.
-                        </Normaltekst>
-                    </Veilederpanel>
-                </Margin40TopContainer>
+            <Margin40TopContainer>
+                <Veilederpanel type={'plakat'} kompakt svg={<img src={VeilederIcon} alt="Veileder" />}>
+                    <Normaltekst>
+                        Hvis NAV har behandlet en sak som gjelder deg og du er uenig i vedtaket, har du flere
+                        valgmuligheter for å belyse saken bedre og få en ny vurdering. Start med å velge hvilket tema
+                        saken gjelder. Du finner denne informasjonen i vedtaket som du har mottatt fra NAV.
+                    </Normaltekst>
+                </Veilederpanel>
+            </Margin40TopContainer>
 
-                <Margin40Container>
-                    <Systemtittel>Hvilket tema gjelder det?</Systemtittel>
-                </Margin40Container>
-            </div>
-            <PointsFlexListContainer>{getLinks()}</PointsFlexListContainer>
+            <Margin40Container>
+                <WhiteBackgroundContainer>
+                    <Systemtittel>Hvilket område gjelder det?</Systemtittel>
+
+                    <Margin40TopContainer>
+                        <PointsFlexListContainer>{getLinks()}</PointsFlexListContainer>
+                    </Margin40TopContainer>
+                </WhiteBackgroundContainer>
+            </Margin40Container>
         </section>
     );
 };

--- a/src/components/inngang/inngang-innsendingsvalg-digital.tsx
+++ b/src/components/inngang/inngang-innsendingsvalg-digital.tsx
@@ -1,7 +1,14 @@
 import { Normaltekst, Sidetittel, Systemtittel } from 'nav-frontend-typografi';
 import React from 'react';
 import LetterOpened from '../../assets/images/icons/LetterOpened';
-import { Margin40Container, MarginContainer, MarginTopContainer } from '../../styled-components/main-styled-components';
+import {
+    CenterInMobileContainer,
+    Margin40Container,
+    Margin40TopContainer,
+    MarginContainer,
+    MarginTopContainer,
+    WhiteBackgroundContainer
+} from '../../styled-components/main-styled-components';
 import { Tema, TemaKey } from '../../types/tema';
 import { LenkepanelBase } from 'nav-frontend-lenkepanel';
 import Lenke from 'nav-frontend-lenker';
@@ -25,44 +32,52 @@ const InngangInnsendingDigital = ({ temaKey, title = Tema[temaKey], saksnummer =
 
     return (
         <div>
-            <Sidetittel>{title}</Sidetittel>
+            <CenterInMobileContainer>
+                <Sidetittel>{title}</Sidetittel>
+            </CenterInMobileContainer>
             <Margin40Container>
-                <Normaltekst>
-                    For å fylle ut og sende inn en klage må du logge inn med elektronisk ID. Hvis du skal sende en anke
-                    eller du skal søke på vegne av andre må du fylle inn personopplysninger manuelt og sende skjema i
-                    posten.
-                </Normaltekst>
-            </Margin40Container>
-            <DigitalContent temaKey={temaKey} saksnummer={saksnummer} />
-            <Margin40Container>
-                <LenkepanelBase href={paperUrl} border>
-                    <div className="lenkepanel-content-with-image">
-                        <div className="icon-container">
-                            <LetterOpened />
-                        </div>
-                        <div>
-                            <Systemtittel className="lenkepanel__heading">Klage via post</Systemtittel>
-                            <MarginTopContainer>
-                                <Normaltekst>
-                                    Klageskjema som sendes inn via post. Også for deg som skal klage på vegne av andre.
-                                </Normaltekst>
-                            </MarginTopContainer>
-                        </div>
-                    </div>
-                </LenkepanelBase>
-            </Margin40Container>
+                <WhiteBackgroundContainer>
+                    <Normaltekst>
+                        For å fylle ut og sende inn en klage må du logge inn med elektronisk ID. Hvis du skal sende en
+                        anke eller du skal søke på vegne av andre må du fylle inn personopplysninger manuelt og sende
+                        skjema i posten.
+                    </Normaltekst>
 
-            <div>
-                Les mer om{' '}
-                <Lenke
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    href="https://www.nav.no/no/nav-og-samfunn/kontakt-nav/klage-ris-og-ros/klagerettigheter"
-                >
-                    dine klagerettigheter på våre tema-sider
-                </Lenke>
-                .
-            </div>
+                    <Margin40TopContainer>
+                        <DigitalContent temaKey={temaKey} saksnummer={saksnummer} />
+                    </Margin40TopContainer>
+                    <Margin40Container>
+                        <LenkepanelBase href={paperUrl} border>
+                            <div className="lenkepanel-content-with-image">
+                                <div className="icon-container">
+                                    <LetterOpened />
+                                </div>
+                                <div>
+                                    <Systemtittel className="lenkepanel__heading">Klage via post</Systemtittel>
+                                    <MarginTopContainer>
+                                        <Normaltekst>
+                                            Klageskjema som sendes inn via post. Også for deg som skal klage på vegne av
+                                            andre.
+                                        </Normaltekst>
+                                    </MarginTopContainer>
+                                </div>
+                            </div>
+                        </LenkepanelBase>
+                    </Margin40Container>
+
+                    <div>
+                        Les mer om{' '}
+                        <Lenke
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            href="https://www.nav.no/no/nav-og-samfunn/kontakt-nav/klage-ris-og-ros/klagerettigheter"
+                        >
+                            dine klagerettigheter på våre tema-sider
+                        </Lenke>
+                        .
+                    </div>
+                </WhiteBackgroundContainer>
+            </Margin40Container>
         </div>
     );
 };
@@ -97,7 +112,7 @@ const DigitalContent = ({ temaKey, saksnummer }: DigitalContentProps) => {
                 </div>
             </KlageLinkPanel>
             <Lenke target="_blank" rel="noopener noreferrer" href="https://www.norge.no/elektronisk-id">
-                Jeg har ikke elektronisk ID
+                Slik skaffer du deg elektronisk ID
             </Lenke>
         </MarginContainer>
     );

--- a/src/components/inngang/inngang-innsendingsvalg-post.tsx
+++ b/src/components/inngang/inngang-innsendingsvalg-post.tsx
@@ -1,7 +1,12 @@
 import { Normaltekst, Sidetittel, Systemtittel } from 'nav-frontend-typografi';
 import React from 'react';
 import LetterOpened from '../../assets/images/icons/LetterOpened';
-import { Margin40Container, MarginTopContainer } from '../../styled-components/main-styled-components';
+import {
+    CenterInMobileContainer,
+    Margin40Container,
+    MarginTopContainer,
+    WhiteBackgroundContainer
+} from '../../styled-components/main-styled-components';
 import { Tema, TemaKey } from '../../types/tema';
 import { LenkepanelBase } from 'nav-frontend-lenkepanel';
 import Lenke from 'nav-frontend-lenker';
@@ -20,47 +25,52 @@ const InngangInnsendingPost = ({ temaKey, title = Tema[temaKey] }: Props) => {
 
     return (
         <div>
-            <Sidetittel>{title}</Sidetittel>
-            <Margin40Container>
-                <Systemtittel>Innsending via post</Systemtittel>
-                <MarginTopContainer>
-                    <Normaltekst>
-                        Klage eller anke på denne tjenesten krever at du må du sende inn via post. Veiviseren hjelper
-                        deg med utfylling av en førsteside og klageskjema. Dette må du skrive ut ut og sende inn til den
-                        adressen som står på førstesiden, sammen med kopi av eventuelle andre dokumenter eller
-                        kvitteringer.
-                    </Normaltekst>
-                </MarginTopContainer>
-            </Margin40Container>
-            <Margin40Container>
-                <LenkepanelBase href={paperUrl} border>
-                    <div className="lenkepanel-content-with-image">
-                        <div className="icon-container">
-                            <LetterOpened />
-                        </div>
-                        <div>
-                            <Systemtittel className="lenkepanel__heading">Skjema for klager</Systemtittel>
-                            <MarginTopContainer>
-                                <Normaltekst>
-                                    Dette velger du når du skal klage på et vedtak du har fått fra NAV.
-                                </Normaltekst>
-                            </MarginTopContainer>
-                        </div>
-                    </div>
-                </LenkepanelBase>
-            </Margin40Container>
+            <CenterInMobileContainer>
+                <Sidetittel>{title}</Sidetittel>
+            </CenterInMobileContainer>
 
-            <div>
-                Les mer om{' '}
-                <Lenke
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    href="https://www.nav.no/no/nav-og-samfunn/kontakt-nav/klage-ris-og-ros/klagerettigheter"
-                >
-                    dine klagerettigheter på våre tema-sider
-                </Lenke>
-                .
-            </div>
+            <WhiteBackgroundContainer>
+                <Margin40Container>
+                    <Systemtittel>Innsending via post</Systemtittel>
+                    <MarginTopContainer>
+                        <Normaltekst>
+                            Klage eller anke på denne tjenesten krever at du må du sende inn via post. Veiviseren
+                            hjelper deg med utfylling av en førsteside og klageskjema. Dette må du skrive ut ut og sende
+                            inn til den adressen som står på førstesiden, sammen med kopi av eventuelle andre dokumenter
+                            eller kvitteringer.
+                        </Normaltekst>
+                    </MarginTopContainer>
+                </Margin40Container>
+                <Margin40Container>
+                    <LenkepanelBase href={paperUrl} border>
+                        <div className="lenkepanel-content-with-image">
+                            <div className="icon-container">
+                                <LetterOpened />
+                            </div>
+                            <div>
+                                <Systemtittel className="lenkepanel__heading">Skjema for klager</Systemtittel>
+                                <MarginTopContainer>
+                                    <Normaltekst>
+                                        Dette velger du når du skal klage på et vedtak du har fått fra NAV.
+                                    </Normaltekst>
+                                </MarginTopContainer>
+                            </div>
+                        </div>
+                    </LenkepanelBase>
+                </Margin40Container>
+
+                <div>
+                    Les mer om{' '}
+                    <Lenke
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        href="https://www.nav.no/no/nav-og-samfunn/kontakt-nav/klage-ris-og-ros/klagerettigheter"
+                    >
+                        dine klagerettigheter på våre tema-sider
+                    </Lenke>
+                    .
+                </div>
+            </WhiteBackgroundContainer>
         </div>
     );
 };

--- a/src/components/inngang/inngang-kategorier.tsx
+++ b/src/components/inngang/inngang-kategorier.tsx
@@ -2,9 +2,11 @@ import React from 'react';
 import { Sidetittel, Systemtittel, Undertittel } from 'nav-frontend-typografi';
 import { InngangKategori } from '../../data/kategorier';
 import {
+    CenterInMobileContainer,
     Margin40Container,
     Margin40TopContainer,
-    PointsFlexListContainer
+    PointsFlexListContainer,
+    WhiteBackgroundContainer
 } from '../../styled-components/main-styled-components';
 import { PageIdentifier } from '../../utils/logger/amplitude';
 import { useLogPageView } from '../../utils/logger/use-log-page-view';
@@ -18,15 +20,21 @@ const InngangKategorier = ({ inngangkategori }: Props) => {
     useLogPageView(PageIdentifier.INNGANG_KATEGORIER);
     return (
         <section>
-            <div>
-                <Margin40TopContainer>
+            <Margin40TopContainer>
+                <CenterInMobileContainer>
                     <Sidetittel>{inngangkategori.title}</Sidetittel>
-                </Margin40TopContainer>
-                <Margin40Container>
+                </CenterInMobileContainer>
+            </Margin40TopContainer>
+
+            <Margin40Container>
+                <WhiteBackgroundContainer>
                     <Systemtittel>Hvilken tjeneste eller ytelse gjelder det?</Systemtittel>
-                </Margin40Container>
-            </div>
-            <PointsFlexListContainer>{getLinks(inngangkategori)}</PointsFlexListContainer>
+
+                    <Margin40TopContainer>
+                        <PointsFlexListContainer>{getLinks(inngangkategori)}</PointsFlexListContainer>
+                    </Margin40TopContainer>
+                </WhiteBackgroundContainer>
+            </Margin40Container>
         </section>
     );
 };

--- a/src/styled-components/main-styled-components.tsx
+++ b/src/styled-components/main-styled-components.tsx
@@ -180,3 +180,18 @@ export const ButtonFlexContainer = styled(FlexContainer)`
         margin-right: 0;
     }
 `;
+
+export const WhiteBackgroundContainer = styled.div`
+    background-color: #fff;
+    padding: 32px;
+`;
+
+export const CenterInMobileContainer = styled.div`
+    margin: 0 auto;
+    @media ${device.mobileS} {
+        text-align: center;
+    }
+    @media ${device.laptop} {
+        text-align: initial;
+    }
+`;

--- a/src/utils/routes.config.tsx
+++ b/src/utils/routes.config.tsx
@@ -84,3 +84,8 @@ function getInngangInnsendingComponent({ digital, title, temaKey }: Kategori) {
     }
     return <InngangInnsendingPost temaKey={temaKey} title={title} />;
 }
+
+export function pathIsPartOfInngang(path: string) {
+    const leadPart = path.split('/')[1];
+    return leadPart !== 'begrunnelse' && leadPart !== 'oppsummering' && leadPart !== 'kvittering';
+}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/19277989/98012618-99d70580-1df9-11eb-9898-4114fd467bb6.png)

Grå bakgrunn i alle sider som ikke er `/begrunnelse`, `/oppsummering` og `/kvittering`.

Burde ses over av designer.