### PR TITLE
Store klage values in sessionStorage during login and as fallback for autosave

### DIFF
--- a/src/auth/login.ts
+++ b/src/auth/login.ts
@@ -2,7 +2,8 @@ import { environment } from '../environment/environment';
 
 export const LOGGED_IN_REDIRECT_PATH_KEY = 'logged-in-redirect-path';
 
-export function login(redirectAfter: string = current(window.location)) {
+export function login() {
+    const redirectAfter = current(window.location);
     localStorage.setItem(LOGGED_IN_REDIRECT_PATH_KEY, redirectAfter);
     window.location.replace(environment.loginUrl);
 }

--- a/src/klage/klage-loader.tsx
+++ b/src/klage/klage-loader.tsx
@@ -3,10 +3,11 @@ import { useParams } from 'react-router-dom';
 import { AlertStripeFeil } from 'nav-frontend-alertstriper';
 import NavFrontendSpinner from 'nav-frontend-spinner';
 import { Normaltekst } from 'nav-frontend-typografi';
-import { getKlage } from '../api/api';
+import { getKlage, updateKlage } from '../api/api';
 import { CenteredContainer } from '../styled-components/common';
 import { AppContext } from '../app-context/app-context';
 import { Klage } from './klage';
+import klageStore from './klage-store';
 
 interface Props {
     render: (klage: Klage) => JSX.Element;
@@ -20,10 +21,23 @@ const KlageLoader = (props: Props) => {
     const { klage, setKlage } = useContext(AppContext);
     const { klageId } = useParams<Match>();
     const [error, setError] = useState<string | null>(null);
+    const [status, setStatus] = useState('Laster klage...');
 
     useEffect(() => {
         if (klage === null || klageId !== klage.id.toString()) {
             getKlage(klageId)
+                .then(klage => {
+                    setStatus('Gjenoppretter klage...');
+                    const restoredKlage = klageStore.restore(klage);
+                    if (restoredKlage !== klage) {
+                        return updateKlage(restoredKlage).then(() => {
+                            klageStore.clear();
+                            return restoredKlage;
+                        });
+                    }
+                    klageStore.clear();
+                    return klage;
+                })
                 .then(setKlage)
                 .catch((error: Error) => setError(formatError(klageId, error)));
         }
@@ -37,7 +51,7 @@ const KlageLoader = (props: Props) => {
         return (
             <CenteredContainer>
                 <NavFrontendSpinner type={'XL'} />
-                <Normaltekst>Laster klage...</Normaltekst>
+                <Normaltekst>{status}</Normaltekst>
             </CenteredContainer>
         );
     }

--- a/src/klage/klage-store.test.ts
+++ b/src/klage/klage-store.test.ts
@@ -1,0 +1,213 @@
+import { TemaKey } from '../tema/tema';
+import { Klage, KlageStatus, VedtakType } from './klage';
+import { KlageStorage, KLAGE_STORAGE_KEYS } from './klage-store';
+
+describe('Klage store', () => {
+    const BASE_KLAGE: Klage = {
+        id: '123',
+        finalizedDate: null,
+        journalpostId: null,
+        modifiedByUser: '2020-12-31T15:45:59.123',
+        saksnummer: null,
+        tema: TemaKey.FOR,
+        vedlegg: [],
+        ytelse: 'En ytelse',
+        status: KlageStatus.DRAFT,
+        fritekst: '',
+        vedtakType: null,
+        vedtakDate: null
+    };
+
+    it('Should store klage values', () => {
+        const storage = new MockStorage();
+        const klageStore = new KlageStorage(storage);
+        const expectedFritekst = 'fritekst';
+        const expectedVedtakDate = '2020-12-31';
+        const expectedVedtakType = VedtakType.EARLIER;
+
+        klageStore.store(expectedFritekst, expectedVedtakType, expectedVedtakDate);
+
+        const fritekst = storage.getItem(KLAGE_STORAGE_KEYS.KLAGE_FRITEKST);
+        const dateOption = storage.getItem(KLAGE_STORAGE_KEYS.KLAGE_VEDTAK_TYPE);
+        const isoDate = storage.getItem(KLAGE_STORAGE_KEYS.KLAGE_VEDTAK_DATE);
+
+        expect(fritekst).toBe(expectedFritekst);
+        expect(dateOption).toBe(expectedVedtakType);
+        expect(isoDate).toBe(expectedVedtakDate);
+    });
+
+    it('Should overwrite klage when fritekst is different, vedtak is equal, and klage status is DRAFT', () => {
+        const storage = new MockStorage();
+        const klageStore = new KlageStorage(storage);
+        const expectedFritekst = 'a new and better fritekst';
+        const expectedVedtakDate = '2020-12-31';
+        const expectedVedtakType = VedtakType.EARLIER;
+
+        klageStore.store(expectedFritekst, expectedVedtakType, expectedVedtakDate);
+
+        const klage: Klage = {
+            ...BASE_KLAGE,
+            status: KlageStatus.DRAFT,
+            fritekst: 'old and poor fritekst',
+            vedtakType: expectedVedtakType,
+            vedtakDate: expectedVedtakDate
+        };
+        const expectedKlage: Klage = {
+            ...klage,
+            fritekst: expectedFritekst,
+            vedtakType: expectedVedtakType,
+            vedtakDate: expectedVedtakDate
+        };
+        const restoredKlage = klageStore.restore(klage);
+
+        expect(restoredKlage).not.toBe(expectedKlage);
+        expect(restoredKlage).toStrictEqual(expectedKlage);
+    });
+
+    it('Should overwrite klage when fritekst is equal, vedtak is different, and klage status is DRAFT', () => {
+        const storage = new MockStorage();
+        const klageStore = new KlageStorage(storage);
+        const expectedFritekst = 'fritekst';
+        const expectedVedtakDate = '2020-12-31';
+        const expectedVedtakType = VedtakType.EARLIER;
+
+        klageStore.store(expectedFritekst, expectedVedtakType, expectedVedtakDate);
+
+        const klage: Klage = {
+            ...BASE_KLAGE,
+            status: KlageStatus.DRAFT,
+            fritekst: expectedFritekst,
+            vedtakType: VedtakType.LATEST,
+            vedtakDate: null
+        };
+        const expectedKlage: Klage = {
+            ...klage,
+            fritekst: expectedFritekst,
+            vedtakType: expectedVedtakType,
+            vedtakDate: expectedVedtakDate
+        };
+        const restoredKlage = klageStore.restore(klage);
+
+        expect(restoredKlage).not.toBe(expectedKlage);
+        expect(restoredKlage).toStrictEqual(expectedKlage);
+    });
+
+    it('Should not overwrite klage when values are null', () => {
+        const storage = new MockStorage();
+        const klageStore = new KlageStorage(storage);
+        const expectedFritekst = 'fritekst';
+        const expectedVedtakDate = '2020-12-31';
+        const expectedVedtakType = VedtakType.EARLIER;
+
+        const expectedKlage: Klage = {
+            ...BASE_KLAGE,
+            status: KlageStatus.DRAFT,
+            fritekst: expectedFritekst,
+            vedtakType: expectedVedtakType,
+            vedtakDate: expectedVedtakDate
+        };
+        const restoredKlage = klageStore.restore(expectedKlage);
+
+        expect(restoredKlage).toBe(expectedKlage);
+    });
+
+    it('Should not overwrite klage when values are equal', () => {
+        const storage = new MockStorage();
+        const klageStore = new KlageStorage(storage);
+        const expectedFritekst = 'fritekst';
+        const expectedVedtakDate = '2020-12-31';
+        const expectedVedtakType = VedtakType.EARLIER;
+
+        klageStore.store(expectedFritekst, expectedVedtakType, expectedVedtakDate);
+
+        const expectedKlage: Klage = {
+            ...BASE_KLAGE,
+            status: KlageStatus.DRAFT,
+            fritekst: expectedFritekst,
+            vedtakType: expectedVedtakType,
+            vedtakDate: expectedVedtakDate
+        };
+        const restoredKlage = klageStore.restore(expectedKlage);
+
+        expect(restoredKlage).toBe(expectedKlage);
+    });
+
+    it('Should not overwrite klage when status is not DRAFT', () => {
+        const storage = new MockStorage();
+        const klageStore = new KlageStorage(storage);
+        const expectedFritekst = 'fritekst';
+        const expectedVedtakDate = '2020-12-31';
+        const expectedVedtakType = VedtakType.EARLIER;
+
+        klageStore.store(expectedFritekst, expectedVedtakType, expectedVedtakDate);
+
+        const expectedKlage: Klage = {
+            ...BASE_KLAGE,
+            status: KlageStatus.DONE,
+            fritekst: 'outdated',
+            vedtakType: expectedVedtakType,
+            vedtakDate: expectedVedtakDate
+        };
+        const restoredKlage = klageStore.restore(expectedKlage);
+
+        expect(restoredKlage).toBe(expectedKlage);
+    });
+
+    it('Should ONLY clear storage keys it owns', () => {
+        const storage = new MockStorage({
+            shouldBe: 'still here',
+            shouldStill: 'be here',
+            [KLAGE_STORAGE_KEYS.KLAGE_FRITEKST]: 'not here',
+            [KLAGE_STORAGE_KEYS.KLAGE_VEDTAK_TYPE]: 'not here',
+            [KLAGE_STORAGE_KEYS.KLAGE_VEDTAK_DATE]: 'not here'
+        });
+        const klageStore = new KlageStorage(storage);
+        klageStore.clear();
+
+        expect(storage.getItem('shouldBe')).toBe('still here');
+        expect(storage.getItem('shouldStill')).toBe('be here');
+        expect(storage.getItem(KLAGE_STORAGE_KEYS.KLAGE_FRITEKST)).toBeNull();
+        expect(storage.getItem(KLAGE_STORAGE_KEYS.KLAGE_VEDTAK_TYPE)).toBeNull();
+        expect(storage.getItem(KLAGE_STORAGE_KEYS.KLAGE_VEDTAK_DATE)).toBeNull();
+    });
+});
+
+class MockStorage implements Storage {
+    private values: Map<string, string>;
+
+    constructor(initialValues: { [name: string]: string } = {}) {
+        this.values = new Map(Object.entries(initialValues));
+    }
+
+    public getItem(key: string): string | null {
+        const value = this.values.get(key);
+        if (typeof value === 'string') {
+            return value;
+        }
+        return null;
+    }
+
+    public setItem(key: string, value: string) {
+        this.values.set(key, value);
+    }
+
+    public removeItem(key: string): void {
+        this.values.delete(key);
+    }
+
+    public key(index: number): string | null {
+        if (index < 0 || index >= this.length) {
+            return null;
+        }
+        const keys = Array.from(this.values.keys());
+        return keys[index];
+    }
+
+    public clear() {
+        this.values.clear();
+    }
+
+    get length(): number {
+        return this.values.size;
+    }
+}

--- a/src/klage/klage-store.ts
+++ b/src/klage/klage-store.ts
@@ -1,0 +1,59 @@
+import { ISODate } from '../date/date';
+import { Klage, KlageStatus, VedtakType } from './klage';
+
+export enum KLAGE_STORAGE_KEYS {
+    KLAGE_FRITEKST = 'KLAGE_FRITEKST',
+    KLAGE_VEDTAK_DATE = 'KLAGE_ISO_DATE',
+    KLAGE_VEDTAK_TYPE = 'KLAGE_DATE_OPTION'
+}
+
+export class KlageStorage {
+    private storage: Storage;
+    private keys = Object.values(KLAGE_STORAGE_KEYS);
+
+    constructor(storage: Storage) {
+        this.storage = storage;
+    }
+
+    private setValue(key: KLAGE_STORAGE_KEYS, value: VedtakType | ISODate | string | null) {
+        if (value === null) {
+            this.storage.removeItem(key);
+        } else {
+            this.storage.setItem(key, value);
+        }
+    }
+
+    public store(fritekst: string, vedtakType: VedtakType | null, vedtakDate: ISODate | null) {
+        this.setValue(KLAGE_STORAGE_KEYS.KLAGE_FRITEKST, fritekst);
+        this.setValue(KLAGE_STORAGE_KEYS.KLAGE_VEDTAK_TYPE, vedtakType);
+        this.setValue(KLAGE_STORAGE_KEYS.KLAGE_VEDTAK_DATE, vedtakDate);
+    }
+
+    public restore(klage: Klage): Klage {
+        if (klage.status !== KlageStatus.DRAFT) {
+            return klage;
+        }
+        const fritekst = this.storage.getItem(KLAGE_STORAGE_KEYS.KLAGE_FRITEKST);
+        const vedtakType = this.storage.getItem(KLAGE_STORAGE_KEYS.KLAGE_VEDTAK_TYPE) as VedtakType | null;
+        const vedtakDate = this.storage.getItem(KLAGE_STORAGE_KEYS.KLAGE_VEDTAK_DATE) as ISODate | null;
+
+        if (
+            (vedtakType === null || vedtakType === klage.vedtakType) &&
+            (vedtakDate === null || vedtakDate === klage.vedtakDate) &&
+            (fritekst === null || fritekst === klage.fritekst)
+        ) {
+            return klage;
+        }
+
+        return {
+            ...klage,
+            fritekst: fritekst ?? klage.fritekst,
+            vedtakType: vedtakType ?? klage.vedtakType,
+            vedtakDate: vedtakDate ?? klage.vedtakDate
+        };
+    }
+
+    public clear = () => this.keys.forEach(key => this.storage.removeItem(key));
+}
+
+export default new KlageStorage(window.sessionStorage);

--- a/src/routes/klageskjema/kvittering/kvittering-page.tsx
+++ b/src/routes/klageskjema/kvittering/kvittering-page.tsx
@@ -11,11 +11,9 @@ interface Props {
 }
 
 const KvitteringPage = ({ klage }: Props) => {
-    const klageJournalpostId = klage?.journalpostId ?? null;
-
-    const [waitingForJoark, setWaitingForJoark] = useState<boolean>(klageJournalpostId === null);
+    const [waitingForJoark, setWaitingForJoark] = useState<boolean>(klage.journalpostId === null);
     const [informStillWorking, setInformStillWorking] = useState<boolean>(false);
-    const [journalPostId, setJournalPostId] = useState<string | null>(klageJournalpostId);
+    const [journalPostId, setJournalPostId] = useState<string | null>(klage.journalpostId);
 
     useLogPageView(PageIdentifier.KLAGESKJEMA_KVITTERING);
 


### PR DESCRIPTION
Lagrer `fritekst`, `vedtakType`, og `vedtakDate` i `sessionStorage` rett før login og kun etter `autosave` eller `save` feiler.

Fiksen for dobbel `PUT` ved restore og unødvendig `PUT` ved vanlig load ble;
- Alltid sette oppdatert klage i context dersom klagen ble lagret `PUT = 200 OK`, både ved `autosave` og vanlig `save`.
- Kun utføre `autosave` dersom `vedtakType`, `vedtakDate` eller `fritekst` er endret ift. klagen i context.