### PR TITLE
Sections and titles to form fields

### DIFF
--- a/src/routes/klageskjema/begrunnelse/attachments/attachments.tsx
+++ b/src/routes/klageskjema/begrunnelse/attachments/attachments.tsx
@@ -1,15 +1,15 @@
 import React, { useState } from 'react';
 import NavFrontendSpinner from 'nav-frontend-spinner';
 import { Normaltekst, Undertekst } from 'nav-frontend-typografi';
+import { Label } from 'nav-frontend-skjema';
 import AttachmentPreview from './preview';
 import UploadButton from './upload-button';
 import { Attachment } from '../../../../klage/attachment';
-import { Section } from '../../../../styled-components/section';
-import { KlageUndertittel } from '../../../../styled-components/undertittel';
 import { CenteredContainer } from '../../../../styled-components/common';
 import { Klage } from '../../../../klage/klage';
 import { PageParagraph } from '../../../../styled-components/page-paragraph';
 import { KlageAlertStripe, KlageAlertStripeFeil } from '../../../../styled-components/alert';
+import { Row } from '../../../../styled-components/row';
 
 interface Props {
     attachments: Attachment[];
@@ -18,13 +18,15 @@ interface Props {
     setIsLoadig: (loading: boolean) => void;
 }
 
+const FILE_INPUT_ID = 'file-upload-input';
+
 const AttachmentsSection = ({ klage, attachments, setAttachments, setIsLoadig }: Props) => {
     const [attachmentsLoading, setAttachmentsLoading] = useState<boolean>(false);
     const [attachmentError, setAttachmentError] = useState<string | null>(null);
 
     return (
-        <Section>
-            <KlageUndertittel>Vedlegg ({attachments.length})</KlageUndertittel>
+        <Row>
+            <Label htmlFor={FILE_INPUT_ID}>Vedlegg ({attachments.length})</Label>
             <AttachmentPreview
                 attachments={attachments}
                 setAttachments={setAttachments}
@@ -36,6 +38,7 @@ const AttachmentsSection = ({ klage, attachments, setAttachments, setIsLoadig }:
             {getAttachmentError(attachmentError)}
 
             <UploadButton
+                inputId={FILE_INPUT_ID}
                 attachments={attachments}
                 setAttachments={setAttachments}
                 setLoading={setAttachmentsLoading}
@@ -52,7 +55,7 @@ const AttachmentsSection = ({ klage, attachments, setAttachments, setIsLoadig }:
                     enn 32 MB.
                 </Undertekst>
             </KlageAlertStripe>
-        </Section>
+        </Row>
     );
 };
 

--- a/src/routes/klageskjema/begrunnelse/attachments/upload-button.tsx
+++ b/src/routes/klageskjema/begrunnelse/attachments/upload-button.tsx
@@ -18,12 +18,13 @@ interface UploadError {
 interface Props {
     klage: Klage;
     attachments: Attachment[];
+    inputId: string;
     setAttachments: (attachments: Attachment[]) => void;
     setLoading: (loading: boolean) => void;
     setError: (error: string) => void;
 }
 
-const UploadButton = ({ klage, attachments, setAttachments, setLoading, setError }: Props) => {
+const UploadButton = ({ inputId, klage, attachments, setAttachments, setLoading, setError }: Props) => {
     const fileInput = useRef<HTMLInputElement>(null);
 
     const handleAttachmentClick = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
@@ -69,6 +70,7 @@ const UploadButton = ({ klage, attachments, setAttachments, setLoading, setError
         <Row>
             <Knapp onClick={handleAttachmentClick}>Last opp nytt vedlegg</Knapp>
             <input
+                id={inputId}
                 type="file"
                 multiple
                 accept="image/png, image/jpeg, image/jpg, .pdf"

--- a/src/routes/klageskjema/begrunnelse/begrunnelse-text.tsx
+++ b/src/routes/klageskjema/begrunnelse/begrunnelse-text.tsx
@@ -5,13 +5,15 @@ interface Props {
     fritekst: string;
     setFritekst: (fritekst: string) => void;
     showErrors: boolean;
+    id: string;
 }
 
-const BegrunnelseText = ({ fritekst, setFritekst, showErrors }: Props) => {
+const BegrunnelseText = ({ id, fritekst, setFritekst, showErrors }: Props) => {
     const [isValid, setIsValid] = useState<boolean>(fritekst.length !== 0);
 
     return (
         <Textarea
+            id={id}
             value={fritekst}
             description={INPUTDESCRIPTION}
             placeholder="Skriv inn din begrunnelse her."

--- a/src/routes/klageskjema/begrunnelse/begrunnelse.tsx
+++ b/src/routes/klageskjema/begrunnelse/begrunnelse.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useContext, useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { Hovedknapp } from 'nav-frontend-knapper';
 import { Normaltekst } from 'nav-frontend-typografi';
+import { Label } from 'nav-frontend-skjema';
 import { updateKlage } from '../../../api/api';
 import { CenteredContainer } from '../../../styled-components/common';
 import { Attachment } from '../../../klage/attachment';
@@ -20,9 +21,8 @@ import BegrunnelseText from './begrunnelse-text';
 import AttachmentsSection from './attachments/attachments';
 import VedtakDate from './vedtak-date';
 import { KlageAlertStripeFeil } from '../../../styled-components/alert';
-import { Section } from '../../../styled-components/section';
-import { KlageUndertittel } from '../../../styled-components/undertittel';
 import Saksnummer from './saksnummer';
+import { Row } from '../../../styled-components/row';
 
 interface Props {
     klage: Klage;
@@ -123,18 +123,20 @@ const Begrunnelse = ({ klage }: Props) => {
                 </KlageAlertStripeFeil>
             )}
 
-            <Section>
-                <KlageUndertittel>Hva er du uenig i?</KlageUndertittel>
-                <Reasons checkedReasons={reasons} setCheckedReasons={setReasons} />
-                <VedtakDate vedtakDate={vedtakDate} setVedtakDate={setVedtakDate} />
-                <Saksnummer saksnummer={saksnummer} setSaksnummer={setSaksnummer} />
-            </Section>
+            <Reasons checkedReasons={reasons} setCheckedReasons={setReasons} />
+            <VedtakDate vedtakDate={vedtakDate} setVedtakDate={setVedtakDate} />
+            <Saksnummer saksnummer={saksnummer} setSaksnummer={setSaksnummer} />
 
-            <Section>
-                <KlageUndertittel>Hvorfor er du uenig?</KlageUndertittel>
-                <BegrunnelseText fritekst={fritekst} setFritekst={setFritekst} showErrors={submitted} />
+            <Row>
+                <Label htmlFor={'begrunnelse-text'}>Hvorfor er du uenig?</Label>
+                <BegrunnelseText
+                    id="begrunnelse-text"
+                    fritekst={fritekst}
+                    setFritekst={setFritekst}
+                    showErrors={submitted}
+                />
                 <AutosaveProgressIndicator autosaveStatus={autosaveStatus} />
-            </Section>
+            </Row>
 
             <AttachmentsSection
                 attachments={attachments}

--- a/src/routes/klageskjema/begrunnelse/reasons.tsx
+++ b/src/routes/klageskjema/begrunnelse/reasons.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
+import styled from 'styled-components/macro';
 import { CheckboksPanelGruppe, CheckboksPanelProps } from 'nav-frontend-skjema';
 import { Reason } from '../../../klage/klage';
-import styled from 'styled-components/macro';
 
 interface Props {
     checkedReasons: Reason[];
@@ -11,6 +11,7 @@ interface Props {
 
 const Reasons = ({ checkedReasons, setCheckedReasons, className }: Props) => (
     <CheckboksPanelGruppe
+        legend={'Hva er du uenig i? (valgfri)'}
         className={className}
         checkboxes={useCheckboxes(checkedReasons)}
         onChange={(_, clickedReason: Reason) => {

--- a/src/routes/klageskjema/begrunnelse/saksnummer.tsx
+++ b/src/routes/klageskjema/begrunnelse/saksnummer.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import styled from 'styled-components/macro';
 import { Input } from 'nav-frontend-skjema';
 
 interface Props {
@@ -6,8 +7,14 @@ interface Props {
     setSaksnummer: (saksnummer: string) => void;
 }
 
+const MarginInput = styled(Input)`
+    && {
+        margin-bottom: 32px;
+    }
+`;
+
 const Saksnummer = ({ saksnummer, setSaksnummer }: Props) => (
-    <Input
+    <MarginInput
         label="Saksnummer (valgfri)"
         bredde="L"
         value={saksnummer ?? ''}

--- a/src/routes/klageskjema/form-container.tsx
+++ b/src/routes/klageskjema/form-container.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import KvitteringPage from './kvittering/kvittering-page';
-import Oppsummering from './oppsummering';
+import Oppsummering from './summary/summary';
 import Begrunnelse from './begrunnelse/begrunnelse';
 import Steps, { stepLabels } from './steps';
 import { Klage } from '../../klage/klage';

--- a/src/routes/klageskjema/summary/checkboxes.tsx
+++ b/src/routes/klageskjema/summary/checkboxes.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import styled from 'styled-components/macro';
+import { Normaltekst } from 'nav-frontend-typografi';
+import { Reason } from '../../../klage/klage';
+import { reasonTexts } from '../begrunnelse/reasons';
+
+interface Props {
+    checkboxesSelected: Reason[];
+}
+
+const Checkboxes = ({ checkboxesSelected }: Props) => {
+    if (checkboxesSelected.length === 0) {
+        return <Normaltekst>Ikke spesifisert.</Normaltekst>;
+    }
+
+    return (
+        <CheckboxList>
+            {checkboxesSelected.map(c => (
+                <CheckboxListItem key={c}>{reasonTexts[c]}</CheckboxListItem>
+            ))}
+        </CheckboxList>
+    );
+};
+
+export default Checkboxes;
+
+const CheckboxList = styled.ul`
+    margin: 0;
+    padding: 0;
+    list-style: none;
+`;
+
+const CheckboxListItem = styled.li`
+    :not(:last-child) {
+        margin-bottom: 4px;
+    }
+`;

--- a/src/routes/klageskjema/summary/summary.tsx
+++ b/src/routes/klageskjema/summary/summary.tsx
@@ -2,28 +2,29 @@ import React, { useState, useContext } from 'react';
 import { useHistory } from 'react-router-dom';
 import styled from 'styled-components/macro';
 import { Hovedknapp, Knapp } from 'nav-frontend-knapper';
-import { AlertStripeFeil } from 'nav-frontend-alertstriper';
 import { Undertittel, Undertekst, Normaltekst } from 'nav-frontend-typografi';
 import Ekspanderbartpanel from 'nav-frontend-ekspanderbartpanel';
-import PersonligeOpplysningerSummary from './summary/personlige-opplysninger-summary';
-import VedtakSummary from './summary/vedtak-summary';
-import { MarginContainer, CenteredContainer, WrapNormaltekst } from '../../styled-components/common';
-import AttachmentSummary from './summary/attachment-summary';
-import { finalizeKlage } from '../../api/api';
-import Clipboard from '../../icons/ClipboardIcon';
-import { ColoredLine } from '../../styled-components/colored-line';
-import { toFiles } from '../../klage/attachment';
-import { PageIdentifier } from '../../logging/amplitude';
-import { useLogPageView } from '../../logging/use-log-page-view';
-import { AppContext } from '../../app-context/app-context';
-import { device } from '../../styled-components/media-queries';
-import { Klage, KlageStatus } from '../../klage/klage';
-import { ExternalLink } from '../../link/link';
-import { CenteredPageSubTitle } from '../../styled-components/page-title';
-import { CustomMarginRow } from '../../styled-components/row';
-import InformationPointBox from './summary/information-point-box';
-import { reasonTexts } from './begrunnelse/reasons';
-import { KlageUndertittel } from '../../styled-components/undertittel';
+import PersonligeOpplysningerSummary from './personlige-opplysninger-summary';
+import VedtakSummary from './vedtak-summary';
+import { CenteredContainer, WrapNormaltekst } from '../../../styled-components/common';
+import AttachmentSummary from './attachment-summary';
+import { finalizeKlage } from '../../../api/api';
+import Clipboard from '../../../icons/ClipboardIcon';
+import { ColoredLine } from '../../../styled-components/colored-line';
+import { toFiles } from '../../../klage/attachment';
+import { PageIdentifier } from '../../../logging/amplitude';
+import { useLogPageView } from '../../../logging/use-log-page-view';
+import { AppContext } from '../../../app-context/app-context';
+import { device } from '../../../styled-components/media-queries';
+import { Klage, KlageStatus } from '../../../klage/klage';
+import { ExternalLink } from '../../../link/link';
+import { CenteredPageSubTitle } from '../../../styled-components/page-title';
+import { CustomMarginRow } from '../../../styled-components/row';
+import InformationPointBox from './information-point-box';
+
+import { KlageUndertittel } from '../../../styled-components/undertittel';
+import Checkboxes from './checkboxes';
+import { KlageAlertStripeFeil } from '../../../styled-components/alert';
 
 interface Props {
     klage: Klage;
@@ -105,11 +106,7 @@ const Oppsummering = ({ klage }: Props) => {
                 <SummarySection>
                     <KlageUndertittel>Begrunnelse i din klage</KlageUndertittel>
                     <InformationPointBox header={'Hva er du uenig i?'}>
-                        <CheckboxList>
-                            {klage.checkboxesSelected.map(c => (
-                                <CheckboxListItem key={c}>{reasonTexts[c]}</CheckboxListItem>
-                            ))}
-                        </CheckboxList>
+                        <Checkboxes checkboxesSelected={klage.checkboxesSelected} />
                     </InformationPointBox>
                     <InformationPointBox header={'Hvorfor er du uenig?'}>
                         <WrapNormaltekst>{klage.fritekst}</WrapNormaltekst>
@@ -121,6 +118,7 @@ const Oppsummering = ({ klage }: Props) => {
                     <AttachmentSummary klage={klage} attachments={toFiles(klage.vedlegg)} />
                 </SummarySection>
             </Frame>
+
             {getError(error)}
 
             <CenteredContainer>
@@ -144,11 +142,9 @@ const getError = (error: string | null) => {
     }
 
     return (
-        <MarginContainer>
-            <AlertStripeFeil>
-                <Normaltekst>{error}</Normaltekst>
-            </AlertStripeFeil>
-        </MarginContainer>
+        <KlageAlertStripeFeil>
+            <Normaltekst>{error}</Normaltekst>
+        </KlageAlertStripeFeil>
     );
 };
 
@@ -194,18 +190,6 @@ const Icon = styled(Clipboard)`
         margin-right: auto;
         margin-bottom: 16px;
         width: 100px;
-    }
-`;
-
-const CheckboxList = styled.ul`
-    margin: 0;
-    padding: 0;
-    list-style: none;
-`;
-
-const CheckboxListItem = styled.li`
-    :not(:last-child) {
-        margin-bottom: 4px;
     }
 `;
 

--- a/src/routes/routes.tsx
+++ b/src/routes/routes.tsx
@@ -7,7 +7,7 @@ import { LOGGED_IN_PATH } from '../environment/environment';
 import Begrunnelse from './klageskjema/begrunnelse/begrunnelse';
 import FormContainer from './klageskjema/form-container';
 import KlageLoader from '../klage/klage-loader';
-import Oppsummering from './klageskjema/oppsummering';
+import Oppsummering from './klageskjema/summary/summary';
 import KvitteringPage from './klageskjema/kvittering/kvittering-page';
 import { InngangKategori, INNGANG_KATEGORIER, Kategori } from '../kategorier/kategorier';
 import AppContextComponenet from '../app-context/app-context';

--- a/src/styled-components/section.tsx
+++ b/src/styled-components/section.tsx
@@ -1,5 +1,0 @@
-import styled from 'styled-components/macro';
-
-export const Section = styled.section`
-    margin-bottom: 32px;
-`;


### PR DESCRIPTION
Endrer `<section>` med `<h2>` til `<label>`. Marginer er beholdt og ev. flyttet slik at avstandene mellom seksjonene av skjemaet er beholdt.

![image](https://user-images.githubusercontent.com/3177301/102629539-94d0da00-414b-11eb-97b8-258cf6959b4e.png)

Lagt til en default tekst dersom bruker ikke har valgt noen grunner:

![image](https://user-images.githubusercontent.com/3177301/102633126-4d991800-4150-11eb-9c61-adbc899e5fbb.png)
