### PR TITLE
Add resume klage before create

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -4,6 +4,7 @@ import { User } from '../user/user';
 import { Attachment } from '../klage/attachment';
 import { environment } from '../environment/environment';
 import { NewKlage, Klage, UpdateKlage, FinalizedKlage } from '../klage/klage';
+import { TemaKey } from '../tema/tema';
 
 export async function getUser() {
     const url = environment.userUrl;
@@ -13,6 +14,11 @@ export async function getUser() {
         logError(error, 'Get user error.', { resource: url });
         throw error;
     }
+}
+
+export async function getDraftKlage(temaKey: TemaKey, ytelse: string, internalSaksnummer: string | null) {
+    const url = environment.draftKlageUrl(temaKey, ytelse, internalSaksnummer);
+    return await getJSON<Klage>(url, 'Ingen påbegynt klage funnet.');
 }
 
 export async function createKlage(klage: NewKlage) {

--- a/src/environment/environment.ts
+++ b/src/environment/environment.ts
@@ -1,4 +1,6 @@
+import queryString from 'query-string';
 import { logError } from '../logging/frontendLogger';
+import { TemaKey } from '../tema/tema';
 
 type KlageId = string | number;
 
@@ -80,6 +82,22 @@ export class Environment {
         return `${this.apiUrl}/klager`;
     }
     klageUrl = (klageId: KlageId): string => `${this.klagerUrl}/${klageId}`;
+    draftKlageUrl = (temaKey: TemaKey, ytelse: string, internalSaksnummer: string | null) => {
+        const query = queryString.stringify(
+            {
+                tema: temaKey,
+                ytelse,
+                internalSaksnummer
+            },
+            {
+                skipNull: true,
+                skipEmptyString: true,
+                sort: false,
+                encode: true
+            }
+        );
+        return `${this.klagerUrl}/draft?${query}`;
+    };
     finalizeKlageUrl = (klageId: KlageId) => `${this.klageUrl(klageId)}/finalize`;
     klageJournalpostIdUrl = (klageId: KlageId) => `${this.klageUrl(klageId)}/journalpostid`;
     klagePdfUrl = (klageId: KlageId) => `${this.apiUrl}/klager/${klageId}/pdf`;


### PR DESCRIPTION
Legger til funksjonalitet som sjekker om bruker har minst én påbegynt klage med samme tema, ytelse/tittel og saksnummer.
Om bruker har flere blir den nyeste valgt og gjenopptatt i frontend. Bruker blir da sendt til `/123/begrunnelse`.
Om bruker ikke har noen påbegynte klager, blir en ny klage opprettet. Bruker blir da sendt til `/124/begrunnelse`.

Hele prosessen er usynlig for bruker og krever ingen interaksjon fra bruker.

Dersom kallet for å hente påbegynte klager feiler, uansett grunn, faller applikasjonen tilbake på å opprette en ny klage.