### PR TITLE
Adding language in new klage

### DIFF
--- a/src/klage/klage.ts
+++ b/src/klage/klage.ts
@@ -15,6 +15,11 @@ export enum Reason {
     UENIG_I_NOE_ANNET = 'UENIG_I_NOE_ANNET'
 }
 
+export enum Language {
+    nb = 'nb',
+    en = 'en'
+}
+
 export interface FinalizedKlage {
     finalizedDate: ISODate;
     modifiedByUser: ISODateTime;
@@ -29,6 +34,7 @@ export interface NewKlage {
     readonly vedtakDate: ISODate | null;
     readonly ytelse: string;
     readonly fullmaktsgiver: string | null;
+    readonly language: Language;
 }
 
 export interface UpdateKlage extends NewKlage {

--- a/src/routes/create-klage.tsx
+++ b/src/routes/create-klage.tsx
@@ -9,6 +9,7 @@ import { AppContext } from '../app-context/app-context';
 import { getTitle } from '../query/get-title';
 import LoadingPage from '../loading-page/loading-page';
 import { foedselsnrFormat } from './klageskjema/summary/text-formatting';
+import { Language } from '../klage/klage';
 
 const CreateKlage = () => {
     const { search } = useLocation();
@@ -65,6 +66,8 @@ async function resumeOrCreateKlage(
 ) {
     const title = getTitle(query, temaKey);
     const saksnummer = getQueryValue(query.saksnummer);
+    const language = getLanguage(query);
+
     const draftKlage = await getDraftKlage(temaKey, title, saksnummer, fullmaktsgiver);
     if (draftKlage !== null) {
         return draftKlage;
@@ -77,12 +80,21 @@ async function resumeOrCreateKlage(
         vedtakDate: null,
         userSaksnummer: null,
         internalSaksnummer: saksnummer,
-        fullmaktsgiver: fullmaktsgiver
+        fullmaktsgiver: fullmaktsgiver,
+        language: language
     });
 }
 
 const finneFullmaktsgiverError = (fnr: string) =>
     `Klarte ikke finne fullmaktsgiver med personnummer ${foedselsnrFormat(fnr)}.`;
 const oppretteKlageError = () => 'Klarte ikke opprette klage';
+
+export function getLanguage(query: queryString.ParsedQuery): Language {
+    const language = getQueryValue(query.language);
+    if (language === null) {
+        return Language.nb;
+    }
+    return language as Language;
+}
 
 export default CreateKlage;

--- a/src/routes/create-klage.tsx
+++ b/src/routes/create-klage.tsx
@@ -66,7 +66,7 @@ async function resumeOrCreateKlage(
 ) {
     const title = getTitle(query, temaKey);
     const saksnummer = getQueryValue(query.saksnummer);
-    const language = getLanguage(query);
+    const language = getLanguage();
 
     const draftKlage = await getDraftKlage(temaKey, title, saksnummer, fullmaktsgiver);
     if (draftKlage !== null) {
@@ -89,12 +89,8 @@ const finneFullmaktsgiverError = (fnr: string) =>
     `Klarte ikke finne fullmaktsgiver med personnummer ${foedselsnrFormat(fnr)}.`;
 const oppretteKlageError = () => 'Klarte ikke opprette klage';
 
-export function getLanguage(query: queryString.ParsedQuery): Language {
-    const language = getQueryValue(query.language);
-    if (language === null) {
-        return Language.nb;
-    }
-    return language as Language;
+export function getLanguage(): Language {
+    return Language.nb;
 }
 
 export default CreateKlage;

--- a/src/routes/klageskjema/begrunnelse/begrunnelse.tsx
+++ b/src/routes/klageskjema/begrunnelse/begrunnelse.tsx
@@ -8,7 +8,7 @@ import { CenteredContainer } from '../../../styled-components/common';
 import { Attachment } from '../../../klage/attachment';
 import { AppContext } from '../../../app-context/app-context';
 import { ISODate } from '../../../date/date';
-import { Klage, KlageStatus, Reason, UpdateKlage } from '../../../klage/klage';
+import { Klage, KlageStatus, Language, Reason, UpdateKlage } from '../../../klage/klage';
 import { NotLoggedInError } from '../../../api/errors';
 import klageStore from '../../../klage/klage-store';
 import { login } from '../../../user/login';
@@ -178,7 +178,8 @@ const createKlageUpdate = (
     userSaksnummer,
     internalSaksnummer: klage.internalSaksnummer,
     fritekst,
-    vedtakDate
+    vedtakDate,
+    language: klage.language ?? Language.nb // temp fix
 });
 
 const getError = (error: Error | null, logIn: () => void) => {

--- a/src/routes/klageskjema/begrunnelse/begrunnelse.tsx
+++ b/src/routes/klageskjema/begrunnelse/begrunnelse.tsx
@@ -8,7 +8,7 @@ import { CenteredContainer } from '../../../styled-components/common';
 import { Attachment } from '../../../klage/attachment';
 import { AppContext } from '../../../app-context/app-context';
 import { ISODate } from '../../../date/date';
-import { Klage, KlageStatus, Language, Reason, UpdateKlage } from '../../../klage/klage';
+import { Klage, KlageStatus, Reason, UpdateKlage } from '../../../klage/klage';
 import { NotLoggedInError } from '../../../api/errors';
 import klageStore from '../../../klage/klage-store';
 import { login } from '../../../user/login';
@@ -179,7 +179,7 @@ const createKlageUpdate = (
     internalSaksnummer: klage.internalSaksnummer,
     fritekst,
     vedtakDate,
-    language: klage.language ?? Language.nb // temp fix
+    language: klage.language
 });
 
 const getError = (error: Error | null, logIn: () => void) => {


### PR DESCRIPTION
Veldig basic innsending av klage med `language`.

Linje 182 i `begrunnelse.tsx` var en temp fix for alle klager som allerede er påbegynt. Jeg regner med at Christian sin PR kommer til å gjøre den overflødig etter hvert.
Jeg så Øyvind hadde en løsning i sin PR for at dette feltet manglet fra oss, men hvis dere diskuterte dere frem til at `language` er obligatorisk fra frontend så sørger vi for det også på påbegynte klager.