### PR TITLE
Vis riktig feilmelding vedlegg

### DIFF
--- a/src/routes/klageskjema/begrunnelse/attachments/upload-button.tsx
+++ b/src/routes/klageskjema/begrunnelse/attachments/upload-button.tsx
@@ -11,8 +11,8 @@ interface UploadError {
     timestamp: ISODateTime;
     status: number;
     error: string;
-    message: string;
     path: string;
+    detail: string;
 }
 
 interface Props {
@@ -48,7 +48,7 @@ const UploadButton = ({ inputId, klage, attachments, setAttachments, setLoading,
             } catch (err) {
                 if (err instanceof ApiError) {
                     const errorBody: UploadError = await err.response.json();
-                    const errorMessage = getAttachmentErrorMessage(errorBody.message);
+                    const errorMessage = getAttachmentErrorMessage(errorBody.detail);
                     setError(getUploadAttachmentErrorMessage(file, errorMessage));
                 } else if (err instanceof Error) {
                     setError(getUploadAttachmentErrorMessage(file, err.message));


### PR DESCRIPTION
Fiks på å lese vedleggsfeil.

Vedleggsfeil gir fra APIet:

```{"title":"Internal Server Error","status":500,"detail":"FILE_COULD_NOT_BE_CONVERTED"}```

Akkurat nå leser frontend `errorBody.message` som er `undefined`, dermed får brukeren opp noe sånt som:

![image](https://user-images.githubusercontent.com/19277989/106914919-c60a6700-6705-11eb-98ca-1876e036393f.png)

Vi må i stedet lese `errorBody.detail` som gir riktig feilmelding, ala:

![image](https://user-images.githubusercontent.com/19277989/106915362-35805680-6706-11eb-91bc-d796719385c3.png)
