### PR TITLE
Reset klage and fullmakt on unload klage

### DIFF
--- a/src/routes/create-klage.tsx
+++ b/src/routes/create-klage.tsx
@@ -16,6 +16,7 @@ const CreateKlage = () => {
     const history = useHistory();
     const { klage, setKlage, setFullmaktsgiver } = useContext(AppContext);
     const [error, setError] = useState<string | null>(null);
+    const [readyToRedirect, setReadyToRedirect] = useState<boolean>(false);
 
     useEffect(() => {
         const query = queryString.parse(search);
@@ -44,7 +45,10 @@ const CreateKlage = () => {
 
         if (fullmaktsgiver === null) {
             resumeOrCreateKlage(temaKey, titleKey, ytelse, saksnummer, fullmaktsgiver)
-                .then(setKlage)
+                .then(k => {
+                    setKlage(k);
+                    setReadyToRedirect(true);
+                })
                 .catch(() => setError(oppretteKlageError()));
             return;
         }
@@ -53,7 +57,10 @@ const CreateKlage = () => {
             .then(setFullmaktsgiver)
             .then(() =>
                 resumeOrCreateKlage(temaKey, titleKey, ytelse, saksnummer, fullmaktsgiver)
-                    .then(setKlage)
+                    .then(k => {
+                        setKlage(k);
+                        setReadyToRedirect(true);
+                    })
                     .catch(() => setError(oppretteKlageError()))
             )
             .catch(() => setError(finneFullmaktsgiverError(fullmaktsgiver)));
@@ -67,7 +74,10 @@ const CreateKlage = () => {
         return <LoadingPage>Oppretter klage...</LoadingPage>;
     }
 
-    return <Redirect to={`/${klage.id}/begrunnelse`} />;
+    if (readyToRedirect) {
+        return <Redirect to={`/${klage.id}/begrunnelse`} />;
+    }
+    return null;
 };
 
 async function resumeOrCreateKlage(

--- a/src/routes/create-klage.tsx
+++ b/src/routes/create-klage.tsx
@@ -18,10 +18,6 @@ const CreateKlage = () => {
     const [error, setError] = useState<string | null>(null);
 
     useEffect(() => {
-        if (klage !== null) {
-            return;
-        }
-
         const query = queryString.parse(search);
 
         const temaKey = ensureStringIsTema(getQueryValue(query.tema));
@@ -30,9 +26,24 @@ const CreateKlage = () => {
             return;
         }
 
+        const ytelse = getQueryValue(query.ytelse);
+        const titleKey = TITLES.ensureTitleKey(getQueryValue(query.tittel));
+        const saksnummer = getQueryValue(query.saksnummer);
         const fullmaktsgiver = getQueryValue(query.fullmaktsgiver);
+
+        if (
+            klage !== null &&
+            klage.tema === temaKey &&
+            klage.titleKey === (titleKey ?? undefined) &&
+            klage.internalSaksnummer === saksnummer &&
+            klage.ytelse === (ytelse ?? undefined) &&
+            klage.fullmaktsgiver === fullmaktsgiver
+        ) {
+            return;
+        }
+
         if (fullmaktsgiver === null) {
-            resumeOrCreateKlage(temaKey, fullmaktsgiver, query)
+            resumeOrCreateKlage(temaKey, titleKey, ytelse, saksnummer, fullmaktsgiver)
                 .then(setKlage)
                 .catch(() => setError(oppretteKlageError()));
             return;
@@ -41,7 +52,7 @@ const CreateKlage = () => {
         getFullmaktsgiver(temaKey, fullmaktsgiver)
             .then(setFullmaktsgiver)
             .then(() =>
-                resumeOrCreateKlage(temaKey, fullmaktsgiver, query)
+                resumeOrCreateKlage(temaKey, titleKey, ytelse, saksnummer, fullmaktsgiver)
                     .then(setKlage)
                     .catch(() => setError(oppretteKlageError()))
             )
@@ -61,12 +72,11 @@ const CreateKlage = () => {
 
 async function resumeOrCreateKlage(
     temaKey: TemaKey,
-    fullmaktsgiver: string | null,
-    query: queryString.ParsedQuery<string>
+    titleKey: string | null,
+    ytelse: string | null,
+    saksnummer: string | null,
+    fullmaktsgiver: string | null
 ) {
-    const ytelse = getQueryValue(query.ytelse);
-    const titleKey = TITLES.ensureTitleKey(getQueryValue(query.tittel));
-    const saksnummer = getQueryValue(query.saksnummer);
     const language = getLanguage();
 
     const draftKlage = await getDraftKlage(temaKey, titleKey, ytelse, saksnummer, fullmaktsgiver);


### PR DESCRIPTION
Fikser en bug som kan forårsake at en klage blir gjenopptatt selv om tema og tittel er endret.

For å reprodusere feilen:
1. Naviger via inngangen.
2. Opprett en klage for Dagpenger (merk deg klage IDen).
3. Naviger tilbake til hovedkategoriene med history back.
4. Opprett en klage for Foreldrepenger.
5. Observer at klagen har samme ID, tema og tittel.

Løsning i denne PRen:
Når `KlageLoader` ikke lenger vises vil `useEffect`-hooken som den bruker kalle cleanup-funksjonen sin og resette klagen og fullmakt i `AppContext`.